### PR TITLE
chore(release): bump version to 0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,21 @@ and Continuum adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 ### Changed
 - _Nothing yet._
 
+---
+
+## [0.2.1] — 2026-06
+
+### Changed
+- Renamed the importable package from `orchestrator` to `continuum`. The
+  distribution is unchanged (`pip install shyftlabs-continuum`); imports are now
+  `import continuum` / `from continuum.… import …`. Runtime config keys
+  (Temporal task queue, memory collection defaults, session key prefix,
+  Prometheus metric names) and the `initialize_orchestrator`/`shutdown_orchestrator`
+  functions are unchanged.
+
+### Added
+- `continuum/py.typed` marker so consumers receive the package's type hints (PEP 561).
+
 ### Deprecated
 - _Nothing yet._
 
@@ -37,5 +52,6 @@ and Continuum adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 Initial public release. See the repository history for details prior to this changelog being introduced.
 
-[Unreleased]: https://github.com/shyftlabs/continuum/compare/v0.2.0...HEAD
+[Unreleased]: https://github.com/shyftlabs/continuum/compare/v0.2.1...HEAD
+[0.2.1]: https://github.com/shyftlabs/continuum/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/shyftlabs/continuum/releases/tag/v0.2.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "shyftlabs-continuum"
-version = "0.2.0"
+version = "0.2.1"
 description = "Agentic Framework for Enterprise-Wide Execution with multi-LLM provider support, observability, and error tracking"
 readme = "README.md"
 requires-python = ">=3.13"


### PR DESCRIPTION
## What
Bumps `version` 0.2.0 → 0.2.1 in `pyproject.toml` and adds the `## [0.2.1]` CHANGELOG entry.

## Why
`0.2.0` is already published to PyPI, so the next release needs a fresh (immutable) version number. This prepares `0.2.1`, which ships the `import continuum` rename.

## Notes
- **Base is `refactor/import-name-continuum`** (the rename PR), so this diff shows *only* the version + CHANGELOG change. After the rename PR merges to `dev`, GitHub auto-retargets this PR to `dev`.
- Verified: `python -m build` produces `shyftlabs_continuum-0.2.1` wheel + sdist; `twine check` passes.
- **Do not publish 0.2.1 until both PRs are merged to `dev`** — then rebuild from merged `dev` and upload.

## Merge order
1. Merge the rename PR (`refactor/import-name-continuum`) → `dev`.
2. Merge this PR (`chore/bump-0.2.1`) → `dev`.
3. Rebuild from `dev` and `twine upload`.
