### PR TITLE
chore(release): bump version to 0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,21 @@ and Continuum adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 ### Changed
 - _Nothing yet._
 
+---
+
+## [0.2.1] — 2026-06
+
+### Changed
+- Renamed the importable package from `orchestrator` to `continuum`. The
+  distribution is unchanged (`pip install shyftlabs-continuum`); imports are now
+  `import continuum` / `from continuum.… import …`. Runtime config keys
+  (Temporal task queue, memory collection defaults, session key prefix,
+  Prometheus metric names) and the `initialize_orchestrator`/`shutdown_orchestrator`
+  functions are unchanged.
+
+### Added
+- `continuum/py.typed` marker so consumers receive the package's type hints (PEP 561).
+
 ### Deprecated
 - _Nothing yet._
 
@@ -37,5 +52,6 @@ and Continuum adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 Initial public release. See the repository history for details prior to this changelog being introduced.
 
-[Unreleased]: https://github.com/shyftlabs/continuum/compare/v0.2.0...HEAD
+[Unreleased]: https://github.com/shyftlabs/continuum/compare/v0.2.1...HEAD
+[0.2.1]: https://github.com/shyftlabs/continuum/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/shyftlabs/continuum/releases/tag/v0.2.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "shyftlabs-continuum"
-version = "0.2.0"
+version = "0.2.1"
 description = "Agentic Framework for Enterprise-Wide Execution with multi-LLM provider support, observability, and error tracking"
 readme = "README.md"
 requires-python = ">=3.13"


### PR DESCRIPTION
## What
Bumps `version` 0.2.0 → 0.2.1 in `pyproject.toml` and adds the `## [0.2.1]` CHANGELOG entry. Two-file diff, no code changes.

## Why
`0.2.0` is already on PyPI (immutable). `dev` now has the `import continuum` rename but is still labelled `0.2.0`, so the next release needs `0.2.1` before it can be published.

## Notes
- Branched fresh off merged `dev` (post-rename), so this is a clean release-only PR.
- Supersedes the earlier `chore/bump-0.2.1` PR (which was stacked on the pre-squash rename branch and now conflicts) — please **close that one**.
- After merge: rebuild from `dev` and `twine upload` the `0.2.1` artifacts.
