### PR TITLE
fix(agent): pop agent_stack on failed handoff; guard recent_turns<=0

### DIFF
--- a/src/continuum/agent/execution/executor.py
+++ b/src/continuum/agent/execution/executor.py
@@ -616,10 +616,14 @@ class Executor(IExecutor):
                                         messages=messages,
                                     )
                             else:
-                                # Handoff failed — clean up stack if return_to_parent
-                                # (push_agent already ran in execute_handoff)
-                                handoff_config = agent.get_handoff(target)
-                                if handoff_config and handoff_config.return_to_parent:
+                                # Handoff failed. execute_handoff pushes the target
+                                # only AFTER its early depth/cycle/registry checks
+                                # pass, so the target is on the stack only in
+                                # post-push failures — where it sits on top. Pop it
+                                # whenever it's on top, regardless of return_to_parent,
+                                # so a failed hop never leaves the target stuck (which
+                                # would trip false cycle detection on a retry).
+                                if run_state.agent_stack and run_state.agent_stack[-1] == target:
                                     run_state.pop_agent()
                                     run_state.current_agent = agent.name
                                 # Add error as tool result so the LLM can react

--- a/src/continuum/agent/handoff/history.py
+++ b/src/continuum/agent/handoff/history.py
@@ -58,6 +58,12 @@ def _find_turn_boundary(messages: list[dict[str, Any]], n_turns: int) -> int:
     A turn starts at each user message. All messages within a turn
     (tool calls, tool results, assistant responses) are included.
     """
+    # n_turns <= 0 means "keep no recent turns". Return an index past the end
+    # so messages[boundary:] == []. Without this guard, n_turns == 0 hits
+    # user_indices[-0] (== user_indices[0]) and returns almost the entire
+    # history instead of nothing.
+    if n_turns <= 0:
+        return len(messages)
     user_indices = [i for i, m in enumerate(messages) if m.get("role") == "user"]
     if len(user_indices) <= n_turns:
         return 0

--- a/src/continuum/utils/sanitization.py
+++ b/src/continuum/utils/sanitization.py
@@ -60,11 +60,13 @@ def sanitize_message_content(message: dict[str, Any]) -> dict[str, Any]:
     return message
 
 
-# Allowlist for user_id and conversation_id: alphanumeric, hyphen, underscore, dot, @
+# Allowlist for user_id and conversation_id: alphanumeric, hyphen, underscore, dot, @, pipe.
 # Colons are explicitly excluded — they are key delimiters in Redis session keys
 # ("c:{conversation_id}:u:{user_id}") and cart_session_id (f"{user_id}:{conversation_id}").
 # A colon in either value would silently collapse into another user's scoping key.
-_ID_ALLOWED_RE = re.compile(r"[^a-zA-Z0-9\-_.@]")
+# Pipe ("|") IS allowed: Auth0-style JWT 'sub' claims look like "auth0|64abc..." and
+# the pipe is not a key delimiter here, so it is safe (PR #55 review follow-up).
+_ID_ALLOWED_RE = re.compile(r"[^a-zA-Z0-9\-_.@|]")
 _ID_MAX_LENGTH = 128
 
 
@@ -112,7 +114,7 @@ def _validate_id(value: str | None, field: str) -> str | None:
             field,
             value,
             f"contains disallowed character {bad.group()!r}; "
-            "allowed characters are letters, digits, and - _ . @",
+            "allowed characters are letters, digits, and - _ . @ |",
         )
     return cleaned
 

--- a/tests/integration/test_handoff_depth_adversarial.py
+++ b/tests/integration/test_handoff_depth_adversarial.py
@@ -1,0 +1,507 @@
+"""
+Adversarial integration tests for handoff depth limiting and cycle detection.
+
+The story: agents can hand off to each other — triage → billing → refund etc.
+Every hand-off pushes a name onto agent_stack. The HandoffExecutor checks that
+stack length before each hop and blocks it once max_depth is reached, returning
+a failed HandoffResult instead of crashing.
+
+Angles covered here:
+  - Happy path: chain up to (but not including) the limit succeeds.
+  - Exact boundary: the hop that would reach max_depth is blocked cleanly.
+  - Custom max_depth: low limits are respected (not hardcoded to 10).
+  - Zero depth: max_depth=0 blocks even the very first handoff.
+  - Cycle detection: A→B→A is caught before the depth check.
+  - Missing target: handoff to an unregistered agent returns a clean failure.
+  - Defined-but-not-registered: agent is in handoff definition but not registry.
+
+All tests run without a real LLM or Redis — we build a minimal HandoffExecutor,
+stub the inner Executor, and pre-load agent_stack on a plain RunState.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from continuum.agent.base import BaseAgent
+from continuum.agent.execution.handoff_executor import HandoffExecutor
+from continuum.agent.handoff.manager import HandoffManager
+from continuum.agent.types import (
+    Handoff,
+    RunState,
+    generate_run_id,
+)
+
+pytestmark = pytest.mark.integration
+
+
+# --------------------------------------------------------------------------- #
+# Helpers
+# --------------------------------------------------------------------------- #
+
+
+def _make_agent(name: str, handoffs: list[Handoff] | None = None) -> BaseAgent:
+    return BaseAgent(
+        name=name,
+        instructions=f"I am {name}.",
+        handoffs=handoffs or [],
+    )
+
+
+def _make_run_state(stack: list[str] | None = None) -> RunState:
+    state = RunState(run_id=generate_run_id())
+    for name in stack or []:
+        state.push_agent(name)
+    return state
+
+
+def _make_tool_call(reason: str = "test reason") -> Any:
+    """Minimal tool-call object that HandoffExecutor can parse."""
+    fn = SimpleNamespace(
+        name="handoff_to_target",
+        arguments=f'{{"reason": "{reason}"}}',
+    )
+    return SimpleNamespace(function=fn, id="tc-001")
+
+
+def _make_executor(
+    max_depth: int = 10,
+    inner_response: str = "done",
+) -> tuple[HandoffExecutor, MagicMock]:
+    """
+    Build a HandoffExecutor wired with a stubbed inner Executor so we never
+    touch a real LLM. The inner executor's execute_loop returns a minimal
+    AgentResponse-like object.
+    """
+    manager = HandoffManager(llm_client=None, max_depth=max_depth)
+
+    inner = MagicMock()
+    inner.execute_loop = AsyncMock(
+        return_value=SimpleNamespace(
+            content=inner_response,
+            structured_output=None,
+            messages=[],
+            turn_count=1,
+            usage=SimpleNamespace(total_tokens=0),
+            agents_used=[],
+            status="success",
+        )
+    )
+
+    executor = HandoffExecutor(
+        handoff_manager=manager,
+        agent_registry={},
+        executor=inner,
+    )
+    return executor, inner
+
+
+def _make_context() -> Any:
+    return SimpleNamespace(
+        run_id=generate_run_id(),
+        session_id=None,
+        trace_id=None,
+        user_id=None,
+        conversation_id=None,
+        metadata={},
+        agent_stack=[],
+        recorder=None,
+        max_turns=25,
+        data_labels=set(),
+        disable_memory_writes=False,
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Depth limit tests
+# --------------------------------------------------------------------------- #
+
+
+class TestHandoffDepthLimit:
+    async def test_chain_below_limit_succeeds(self) -> None:
+        """9 hops with max_depth=10 — all should succeed."""
+        executor, _ = _make_executor(max_depth=10)
+
+        # Pre-build 8 agents already in the stack (depth 8).
+        # We attempt the 9th hop here — should pass (9 < 10).
+        agent_a = _make_agent("agent-8", handoffs=[Handoff(target_agent="agent-9", description="")])
+        agent_b = _make_agent("agent-9")
+        executor.register_agent(agent_a)
+        executor.register_agent(agent_b)
+
+        state = _make_run_state(stack=[f"agent-{i}" for i in range(8)])
+        ctx = _make_context()
+
+        result = await executor.execute_handoff(
+            agent=agent_a,
+            target_name="agent-9",
+            tool_call=_make_tool_call(),
+            messages=[],
+            context=ctx,
+            run_state=state,
+        )
+
+        assert result.success is True
+
+    async def test_hop_at_exact_limit_is_blocked(self) -> None:
+        """The hop that would make depth == max_depth must be rejected."""
+        executor, _ = _make_executor(max_depth=10)
+
+        agent_a = _make_agent(
+            "agent-10", handoffs=[Handoff(target_agent="agent-11", description="")]
+        )
+        agent_b = _make_agent("agent-11")
+        executor.register_agent(agent_a)
+        executor.register_agent(agent_b)
+
+        # Stack already has 10 names — next hop would be depth 11, over the limit.
+        state = _make_run_state(stack=[f"agent-{i}" for i in range(10)])
+        ctx = _make_context()
+
+        result = await executor.execute_handoff(
+            agent=agent_a,
+            target_name="agent-11",
+            tool_call=_make_tool_call(),
+            messages=[],
+            context=ctx,
+            run_state=state,
+        )
+
+        assert result.success is False
+        assert "depth" in result.error.lower()
+
+    async def test_custom_max_depth_respected(self) -> None:
+        """max_depth=2 blocks the 3rd hop — the limit is not hardcoded."""
+        executor, _ = _make_executor(max_depth=2)
+
+        src = _make_agent("src", handoffs=[Handoff(target_agent="dst", description="")])
+        dst = _make_agent("dst")
+        executor.register_agent(src)
+        executor.register_agent(dst)
+
+        # Stack already has 2 agents — 3rd hop should be blocked.
+        state = _make_run_state(stack=["agent-0", "agent-1"])
+        ctx = _make_context()
+
+        result = await executor.execute_handoff(
+            agent=src,
+            target_name="dst",
+            tool_call=_make_tool_call(),
+            messages=[],
+            context=ctx,
+            run_state=state,
+        )
+
+        assert result.success is False
+        assert "depth" in result.error.lower()
+
+    async def test_max_depth_zero_blocks_first_hop(self) -> None:
+        """max_depth=0 means no handoffs at all — even the first one is blocked."""
+        executor, _ = _make_executor(max_depth=0)
+
+        src = _make_agent("src", handoffs=[Handoff(target_agent="dst", description="")])
+        dst = _make_agent("dst")
+        executor.register_agent(src)
+        executor.register_agent(dst)
+
+        state = _make_run_state()  # empty stack
+        ctx = _make_context()
+
+        result = await executor.execute_handoff(
+            agent=src,
+            target_name="dst",
+            tool_call=_make_tool_call(),
+            messages=[],
+            context=ctx,
+            run_state=state,
+        )
+
+        assert result.success is False
+        assert "depth" in result.error.lower()
+
+    async def test_successful_hop_pushes_onto_stack(self) -> None:
+        """After a successful handoff the target name is on the stack."""
+        executor, _ = _make_executor(max_depth=10)
+
+        src = _make_agent("src", handoffs=[Handoff(target_agent="dst", description="")])
+        dst = _make_agent("dst")
+        executor.register_agent(src)
+        executor.register_agent(dst)
+
+        state = _make_run_state()
+        ctx = _make_context()
+
+        result = await executor.execute_handoff(
+            agent=src,
+            target_name="dst",
+            tool_call=_make_tool_call(),
+            messages=[],
+            context=ctx,
+            run_state=state,
+        )
+
+        assert result.success is True
+        assert "dst" in state.agent_stack
+
+
+# --------------------------------------------------------------------------- #
+# Cycle detection tests
+# --------------------------------------------------------------------------- #
+
+
+class TestHandoffCycleDetection:
+    async def test_direct_cycle_is_blocked(self) -> None:
+        """A → B → A: B trying to hand back to A is a cycle."""
+        executor, _ = _make_executor(max_depth=10)
+
+        agent_a = _make_agent("agent-a")
+        agent_b = _make_agent("agent-b", handoffs=[Handoff(target_agent="agent-a", description="")])
+        executor.register_agent(agent_a)
+        executor.register_agent(agent_b)
+
+        # agent-a is already in the stack (it was the origin).
+        state = _make_run_state(stack=["agent-a"])
+        ctx = _make_context()
+
+        result = await executor.execute_handoff(
+            agent=agent_b,
+            target_name="agent-a",
+            tool_call=_make_tool_call("needs to go back to a"),
+            messages=[],
+            context=ctx,
+            run_state=state,
+        )
+
+        assert result.success is False
+        assert "cycle" in result.error.lower()
+
+    async def test_indirect_cycle_is_blocked(self) -> None:
+        """A → B → C → A: C trying to hand off to A is also a cycle."""
+        executor, _ = _make_executor(max_depth=10)
+
+        agent_a = _make_agent("agent-a")
+        agent_c = _make_agent("agent-c", handoffs=[Handoff(target_agent="agent-a", description="")])
+        executor.register_agent(agent_a)
+        executor.register_agent(agent_c)
+
+        # A and B already in the stack.
+        state = _make_run_state(stack=["agent-a", "agent-b"])
+        ctx = _make_context()
+
+        result = await executor.execute_handoff(
+            agent=agent_c,
+            target_name="agent-a",
+            tool_call=_make_tool_call(),
+            messages=[],
+            context=ctx,
+            run_state=state,
+        )
+
+        assert result.success is False
+        assert "cycle" in result.error.lower()
+
+    async def test_non_cycle_different_target_succeeds(self) -> None:
+        """A → B → C (C not in stack) is NOT a cycle and must succeed."""
+        executor, _ = _make_executor(max_depth=10)
+
+        agent_b = _make_agent("agent-b", handoffs=[Handoff(target_agent="agent-c", description="")])
+        agent_c = _make_agent("agent-c")
+        executor.register_agent(agent_b)
+        executor.register_agent(agent_c)
+
+        state = _make_run_state(stack=["agent-a"])  # only A in stack, C is fresh
+        ctx = _make_context()
+
+        result = await executor.execute_handoff(
+            agent=agent_b,
+            target_name="agent-c",
+            tool_call=_make_tool_call(),
+            messages=[],
+            context=ctx,
+            run_state=state,
+        )
+
+        assert result.success is True
+
+
+# --------------------------------------------------------------------------- #
+# Missing / unregistered target
+# --------------------------------------------------------------------------- #
+
+
+class TestHandoffMissingTarget:
+    async def test_unregistered_and_undefined_target_fails_cleanly(self) -> None:
+        """Target not in registry AND not in agent's handoff list → clean failure."""
+        executor, _ = _make_executor()
+
+        src = _make_agent("src")  # no handoffs declared
+        executor.register_agent(src)
+
+        state = _make_run_state()
+        ctx = _make_context()
+
+        result = await executor.execute_handoff(
+            agent=src,
+            target_name="ghost-agent",
+            tool_call=_make_tool_call(),
+            messages=[],
+            context=ctx,
+            run_state=state,
+        )
+
+        assert result.success is False
+        assert "ghost-agent" in result.error
+
+    async def test_defined_but_not_registered_target_fails_cleanly(self) -> None:
+        """Target declared in handoffs but never registered → clean failure, not KeyError."""
+        executor, _ = _make_executor()
+
+        src = _make_agent(
+            "src",
+            handoffs=[Handoff(target_agent="billing", description="send billing questions here")],
+        )
+        executor.register_agent(src)
+        # Note: "billing" agent is intentionally NOT registered.
+
+        state = _make_run_state()
+        ctx = _make_context()
+
+        result = await executor.execute_handoff(
+            agent=src,
+            target_name="billing",
+            tool_call=_make_tool_call("billing question"),
+            messages=[],
+            context=ctx,
+            run_state=state,
+        )
+
+        assert result.success is False
+        assert "billing" in result.error
+
+
+# --------------------------------------------------------------------------- #
+# Diamond / convergent topology: A→B and A→C both hand off to D
+# --------------------------------------------------------------------------- #
+
+
+class TestDiamondTopology:
+    """
+    The diamond:  A forks into B and C (parallel branches),
+                  then both B and C try to hand off to D.
+
+                      A
+                     / \\
+                    B   C
+                     \\ /
+                      D
+
+    Key question: does B→D and C→D interfere with each other?
+
+    Answer depends on whether they share the same run_state:
+    - Isolated run_state per branch (the parallel workflow does this via branch_copy):
+      each branch has its own agent_stack so D is not seen as a cycle → both succeed.
+    - Shared run_state (a developer manually reuses the same state):
+      B pushes D; now D is in the stack; C tries D → false cycle detected.
+      This is the adversarial "shared state" scenario worth knowing about.
+    """
+
+    async def test_isolated_states_both_branches_reach_D(self) -> None:
+        """
+        Each branch has its own RunState (as the parallel workflow provides).
+        B→D and C→D run concurrently — both should succeed independently.
+        """
+        import asyncio
+
+        executor, _ = _make_executor(max_depth=10)
+
+        agent_b = _make_agent("agent-b", handoffs=[Handoff(target_agent="agent-d", description="")])
+        agent_c = _make_agent("agent-c", handoffs=[Handoff(target_agent="agent-d", description="")])
+        agent_d = _make_agent("agent-d")
+        executor.register_agent(agent_b)
+        executor.register_agent(agent_c)
+        executor.register_agent(agent_d)
+
+        # Each branch starts with its own stack — A is the common ancestor.
+        state_b = _make_run_state(stack=["agent-a", "agent-b"])
+        state_c = _make_run_state(stack=["agent-a", "agent-c"])
+
+        ctx_b = _make_context()
+        ctx_c = _make_context()
+
+        result_b, result_c = await asyncio.gather(
+            executor.execute_handoff(
+                agent=agent_b,
+                target_name="agent-d",
+                tool_call=_make_tool_call(),
+                messages=[],
+                context=ctx_b,
+                run_state=state_b,
+            ),
+            executor.execute_handoff(
+                agent=agent_c,
+                target_name="agent-d",
+                tool_call=_make_tool_call(),
+                messages=[],
+                context=ctx_c,
+                run_state=state_c,
+            ),
+        )
+
+        # Both branches reach D independently — no false cycle.
+        assert result_b.success is True, f"B→D failed: {result_b.error}"
+        assert result_c.success is True, f"C→D failed: {result_c.error}"
+
+    async def test_shared_state_second_branch_sees_false_cycle(self) -> None:
+        """
+        When both branches share the SAME RunState (incorrect usage),
+        B pushes D onto the stack first. C then tries to hand off to D,
+        but D is now in the shared stack → cycle detected.
+
+        This documents the footgun: sharing run_state across concurrent branches
+        causes false cycle errors. The fix is branch_copy() (what the parallel
+        workflow already does).
+        """
+        executor, _ = _make_executor(max_depth=10)
+
+        agent_b = _make_agent("agent-b", handoffs=[Handoff(target_agent="agent-d", description="")])
+        agent_c = _make_agent("agent-c", handoffs=[Handoff(target_agent="agent-d", description="")])
+        agent_d = _make_agent("agent-d")
+        executor.register_agent(agent_b)
+        executor.register_agent(agent_c)
+        executor.register_agent(agent_d)
+
+        # Shared state — the dangerous case.
+        shared_state = _make_run_state(stack=["agent-a"])
+        ctx_b = _make_context()
+        ctx_c = _make_context()
+
+        # Run sequentially (not concurrently) to get a deterministic outcome:
+        # first B→D succeeds and mutates the shared stack, then C→D is affected.
+        result_b = await executor.execute_handoff(
+            agent=agent_b,
+            target_name="agent-d",
+            tool_call=_make_tool_call(),
+            messages=[],
+            context=ctx_b,
+            run_state=shared_state,
+        )
+        result_c = await executor.execute_handoff(
+            agent=agent_c,
+            target_name="agent-d",
+            tool_call=_make_tool_call(),
+            messages=[],
+            context=ctx_c,
+            run_state=shared_state,
+        )
+
+        # B succeeds — it runs first, D is not yet in the stack.
+        assert result_b.success is True, f"B→D unexpectedly failed: {result_b.error}"
+
+        # C is blocked — D is now in the shared stack, looks like a cycle.
+        # This is a false positive caused by shared state, not a real cycle.
+        assert result_c.success is False
+        assert "cycle" in result_c.error.lower()

--- a/tests/integration/test_handoff_stack_cleanup_adversarial.py
+++ b/tests/integration/test_handoff_stack_cleanup_adversarial.py
@@ -1,0 +1,267 @@
+"""
+Adversarial integration tests for agent_stack cleanup on handoff FAILURE.
+
+Issue under test:
+    "agent_stack not popped on handoff failure → unbounded growth on repeated
+     failures."
+
+Background — who owns the push and the pop:
+    * ``HandoffExecutor.execute_handoff`` PUSHES the target onto
+      ``run_state.agent_stack`` right before it runs the target agent.
+    * The caller, ``Executor.execute_loop``, owns the POP. It pops in three of
+      the four post-push outcomes:
+        - success + return_to_parent   → pops
+        - success + no return_to_parent → returns up (run ends; harmless)
+        - failure + return_to_parent   → pops
+        - failure + NO return_to_parent → *** does NOT pop *** ← the leak
+
+So the failing path is specifically: a handoff whose target raises during
+execution, on a Handoff configured with ``return_to_parent=False``. The target
+name is left stuck on the stack. The observable consequences:
+    1. The stack does not return to its clean state after the failed hop.
+    2. A retry of the SAME target is then rejected as a false "cycle", because
+       cycle detection sees the stuck name still in the stack.
+
+These tests drive the REAL ``Executor.execute_loop`` (not a stub) with a scripted
+LLM client, so they exercise the true production push/pop path end to end.
+
+No real LLM, Redis, or network — the LLM client is a MagicMock with a scripted
+``chat`` coroutine.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from continuum.agent.base import BaseAgent
+from continuum.agent.execution.executor import Executor
+from continuum.agent.execution.handoff_executor import HandoffExecutor
+from continuum.agent.handoff.manager import HandoffManager
+from continuum.agent.types import Handoff, RunContext, RunState, generate_run_id
+
+pytestmark = pytest.mark.integration
+
+
+# --------------------------------------------------------------------------- #
+# Helpers
+# --------------------------------------------------------------------------- #
+
+
+def _make_agent(name: str, handoffs: list[Handoff] | None = None) -> BaseAgent:
+    return BaseAgent(name=name, instructions=f"I am {name}.", handoffs=handoffs or [])
+
+
+class _FakeToolCall:
+    """Mirrors a real LLM ToolCall: attribute access (.function.name, .id) AND
+    .to_dict() so the executor can serialize it into the assistant message the
+    same way it does in production."""
+
+    def __init__(self, name: str, arguments: str, tc_id: str):
+        self.function = SimpleNamespace(name=name, arguments=arguments)
+        self.id = tc_id
+        self.type = "function"
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "type": "function",
+            "function": {"name": self.function.name, "arguments": self.function.arguments},
+        }
+
+
+def _handoff_tool_call(target: str, tc_id: str = "tc-1") -> Any:
+    """A scripted LLM tool call requesting handoff_to_<target>."""
+    return _FakeToolCall(f"handoff_to_{target}", '{"reason": "test"}', tc_id)
+
+
+def _llm_response(content: str | None = None, tool_calls: list[Any] | None = None) -> Any:
+    """Minimal object matching what Executor reads off an LLM response."""
+    return SimpleNamespace(
+        content=content,
+        tool_calls=tool_calls,
+        usage=SimpleNamespace(prompt_tokens=0, completion_tokens=0, total_tokens=0),
+        model="test-model",
+    )
+
+
+def _build_executor(chat_side_effect: Any) -> tuple[Executor, HandoffExecutor]:
+    """Wire a real Executor + HandoffExecutor with a scripted LLM client."""
+    manager = HandoffManager(llm_client=None, max_depth=10)
+    handoff_executor = HandoffExecutor(handoff_manager=manager, agent_registry={})
+
+    llm = MagicMock()
+    llm.chat = AsyncMock(side_effect=chat_side_effect)
+
+    # Executor.__init__ back-wires handoff_executor._executor = self.
+    executor = Executor(
+        llm_client=llm,
+        tool_handler=None,
+        handoff_executor=handoff_executor,
+    )
+    return executor, handoff_executor
+
+
+def _run_state_with_root(root: str) -> RunState:
+    """Mirror create_run_state: the root agent starts on the stack."""
+    state = RunState(run_id=generate_run_id())
+    state.push_agent(root)
+    state.current_agent = root
+    state.entry_agent = root
+    return state
+
+
+def _context() -> RunContext:
+    return RunContext(run_id=generate_run_id(), max_turns=10)
+
+
+# --------------------------------------------------------------------------- #
+# The leak: failure + return_to_parent=False
+# --------------------------------------------------------------------------- #
+
+
+class TestHandoffFailureStackCleanup:
+    async def test_failed_handoff_no_return_to_parent_leaks_stack(self) -> None:
+        """
+        PRIMARY repro. src hands off to dst (return_to_parent=False). dst raises
+        mid-execution, so the handoff fails. After the run completes, the stack
+        should be back to its clean state (['src']) — dst must not be stuck on it.
+        """
+        call_n = {"i": 0}
+
+        async def chat(*args: Any, **kwargs: Any) -> Any:
+            call_n["i"] += 1
+            i = call_n["i"]
+            if i == 1:
+                # src turn 1 → request the handoff
+                return _llm_response(tool_calls=[_handoff_tool_call("dst")])
+            if i == 2:
+                # dst turn 1 → blow up so the handoff fails AFTER the push
+                raise RuntimeError("dst execution boom")
+            # src turn 2 → recover with a plain answer, no more tool calls
+            return _llm_response(content="recovered without the handoff")
+
+        executor, he = _build_executor(chat)
+        src = _make_agent(
+            "src",
+            handoffs=[Handoff(target_agent="dst", description="", return_to_parent=False)],
+        )
+        dst = _make_agent("dst")
+        he.register_agent(src)
+        he.register_agent(dst)
+
+        state = _run_state_with_root("src")
+        ctx = _context()
+
+        response = await executor.execute_loop(
+            agent=src,
+            messages=[{"role": "user", "content": "hi"}],
+            context=ctx,
+            run_state=state,
+        )
+
+        # The run itself recovers and returns a normal response...
+        assert response.content == "recovered without the handoff"
+        # ...but the stack must be clean. THIS is the bug: dst is left behind.
+        assert "dst" not in state.agent_stack, (
+            f"dst leaked onto the stack after a failed handoff: {state.agent_stack}"
+        )
+        assert state.agent_stack == ["src"]
+
+    async def test_failed_handoff_with_return_to_parent_cleans_stack(self) -> None:
+        """
+        CONTROL. Same failure, but return_to_parent=True. The executor's failure
+        branch pops here, so the stack IS cleaned. This passing while the test
+        above fails pinpoints the missing pop to the return_to_parent=False path.
+        """
+        call_n = {"i": 0}
+
+        async def chat(*args: Any, **kwargs: Any) -> Any:
+            call_n["i"] += 1
+            i = call_n["i"]
+            if i == 1:
+                return _llm_response(tool_calls=[_handoff_tool_call("dst")])
+            if i == 2:
+                raise RuntimeError("dst execution boom")
+            return _llm_response(content="recovered")
+
+        executor, he = _build_executor(chat)
+        src = _make_agent(
+            "src",
+            handoffs=[Handoff(target_agent="dst", description="", return_to_parent=True)],
+        )
+        dst = _make_agent("dst")
+        he.register_agent(src)
+        he.register_agent(dst)
+
+        state = _run_state_with_root("src")
+        ctx = _context()
+
+        await executor.execute_loop(
+            agent=src,
+            messages=[{"role": "user", "content": "hi"}],
+            context=ctx,
+            run_state=state,
+        )
+
+        assert state.agent_stack == ["src"]
+
+    async def test_repeated_failed_handoff_same_target_allows_retry(self) -> None:
+        """
+        CONSEQUENCE (fixed behavior). After the first failed handoff, dst is
+        popped cleanly (return_to_parent=False). src then retries the SAME
+        target. Because the stack is clean, the retry is NOT rejected as a
+        false cycle — it is allowed to run, and this time dst succeeds.
+
+        Before the fix, the leaked dst entry caused cycle detection to block
+        this retry with a false 'cycle' error.
+        """
+        call_n = {"i": 0}
+
+        async def chat(*args: Any, **kwargs: Any) -> Any:
+            call_n["i"] += 1
+            i = call_n["i"]
+            if i == 1:
+                return _llm_response(tool_calls=[_handoff_tool_call("dst", "tc-1")])
+            if i == 2:
+                raise RuntimeError("dst execution boom")  # first attempt fails
+            if i == 3:
+                return _llm_response(tool_calls=[_handoff_tool_call("dst", "tc-2")])  # retry
+            return _llm_response(content="dst recovered on retry")
+
+        executor, he = _build_executor(chat)
+        src = _make_agent(
+            "src",
+            handoffs=[Handoff(target_agent="dst", description="", return_to_parent=False)],
+        )
+        dst = _make_agent("dst")
+        he.register_agent(src)
+        he.register_agent(dst)
+
+        state = _run_state_with_root("src")
+        ctx = _context()
+
+        response = await executor.execute_loop(
+            agent=src,
+            messages=[{"role": "user", "content": "hi"}],
+            context=ctx,
+            run_state=state,
+        )
+
+        # No tool result should mention a cycle — the leaked-entry false positive
+        # is gone now that the failed hop pops cleanly.
+        tool_msgs = [m.get("content", "") for m in state.messages if m.get("role") == "tool"]
+        joined = " ".join(tool_msgs).lower()
+        assert "cycle" not in joined, (
+            "retry was wrongly rejected as a cycle — the stack was not cleaned "
+            f"after the first failure; tool messages were: {tool_msgs}"
+        )
+        # The retry was allowed and actually ran dst this time (proving it was
+        # not blocked by a leftover stack entry). Note: a successful
+        # return_to_parent=False handoff ends the run and returns dst's answer
+        # directly, so the terminal stack state is not asserted here — the leak
+        # itself is covered by test_failed_handoff_no_return_to_parent_leaks_stack.
+        assert response.content == "dst recovered on retry"

--- a/tests/integration/test_handoff_summarization_adversarial.py
+++ b/tests/integration/test_handoff_summarization_adversarial.py
@@ -1,0 +1,235 @@
+"""
+Adversarial integration tests for handoff history summarization.
+
+Covers the issue #25 requirement to exercise *every* summarization mode used when
+one agent hands off to another:
+
+    FULL       - pass the entire history through untouched
+    RECENT_N   - keep only the last N conversation turns
+    SUMMARY    - collapse history into a single summary message (LLM or text)
+    HYBRID     - summarize older turns + keep the last N verbatim
+
+The machinery under test is ``continuum.agent.handoff.history`` — both the async
+``HistorySummarizer.summarize`` (used by ``HandoffManager.prepare_handoff``) and
+the sync ``summarize_conversation`` convenience wrapper. Both route turn-boundary
+selection through ``_find_turn_boundary``.
+
+Hostile angles probed here:
+  - empty history, single message, history with no user turns
+  - RECENT_N / HYBRID with N larger than the conversation
+  - RECENT_N / HYBRID with N == 0   (boundary bug, see HSUM-01)
+  - RECENT_N / HYBRID with negative N (IndexError crash, see HSUM-02)
+  - SUMMARY with no LLM client (text fallback) and with an LLM that raises
+  - deepcopy isolation: a returned message must not alias the input
+
+These are pure-Python paths (no external service), but the SUMMARY LLM path is
+driven with an injected fake async client so nothing real is contacted. Marked
+@pytest.mark.integration per the issue's deliverable convention.
+
+FIXED DEFECTS (these were originally asserted as xfail(strict=True); the fix in
+``_find_turn_boundary`` guards ``n_turns <= 0`` by returning ``len(messages)``,
+so the tests below now assert the corrected behavior directly):
+  HSUM-01  RECENT_N/HYBRID with recent_turns=0 kept the WHOLE history instead of
+           zero recent turns. Root cause: ``user_indices[-n_turns]`` with n==0 is
+           ``user_indices[0]`` (no negative-zero index in Python), so the boundary
+           collapsed to 0 == "keep everything". Fixed.
+  HSUM-02  RECENT_N/HYBRID with a negative recent_turns raised IndexError instead
+           of degrading gracefully. Fixed by the same ``n_turns <= 0`` guard.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from continuum.agent.handoff.history import (
+    HistorySummarizer,
+    _find_turn_boundary,
+    summarize_conversation,
+)
+from continuum.agent.types import HistorySummarizationMode as Mode
+
+pytestmark = pytest.mark.integration
+
+
+# --------------------------------------------------------------------------- #
+# Fixtures / helpers
+# --------------------------------------------------------------------------- #
+def _convo(n_turns: int) -> list[dict[str, Any]]:
+    """Build a conversation of ``n_turns`` user/assistant pairs."""
+    msgs: list[dict[str, Any]] = []
+    for i in range(1, n_turns + 1):
+        msgs.append({"role": "user", "content": f"q{i}"})
+        msgs.append({"role": "assistant", "content": f"a{i}"})
+    return msgs
+
+
+def _user_count(messages: list[dict[str, Any]]) -> int:
+    return sum(1 for m in messages if m.get("role") == "user")
+
+
+class _FakeLLM:
+    """Minimal async LLM stub for the SUMMARY path — contacts nothing real."""
+
+    def __init__(self, content: str = "CONDENSED SUMMARY", raises: bool = False):
+        self._content = content
+        self._raises = raises
+        self.calls = 0
+
+    async def chat(self, messages: Any, config: Any = None, auto_session: bool = False) -> Any:
+        self.calls += 1
+        if self._raises:
+            raise RuntimeError("summarizer LLM unavailable")
+        return SimpleNamespace(content=self._content)
+
+
+# --------------------------------------------------------------------------- #
+# FULL
+# --------------------------------------------------------------------------- #
+class TestFullMode:
+    async def test_full_returns_entire_history(self) -> None:
+        msgs = _convo(3)
+        out = await HistorySummarizer(mode=Mode.FULL).summarize(msgs)
+        assert [m["content"] for m in out] == [m["content"] for m in msgs]
+
+    async def test_full_is_a_deepcopy_not_an_alias(self) -> None:
+        msgs = _convo(2)
+        out = await HistorySummarizer(mode=Mode.FULL).summarize(msgs)
+        out[0]["content"] = "MUTATED"
+        # Mutating the handoff payload must not corrupt the caller's history.
+        assert msgs[0]["content"] == "q1"
+
+    async def test_full_empty_history(self) -> None:
+        assert await HistorySummarizer(mode=Mode.FULL).summarize([]) == []
+
+
+# --------------------------------------------------------------------------- #
+# RECENT_N
+# --------------------------------------------------------------------------- #
+class TestRecentNMode:
+    async def test_keeps_last_n_turns(self) -> None:
+        msgs = _convo(5)  # 5 user turns, 10 messages
+        out = await HistorySummarizer(mode=Mode.RECENT_N, recent_turns=2).summarize(msgs)
+        # Last 2 turns => q4,a4,q5,a5
+        assert [m["content"] for m in out] == ["q4", "a4", "q5", "a5"]
+
+    async def test_n_larger_than_history_keeps_all(self) -> None:
+        msgs = _convo(2)
+        out = await HistorySummarizer(mode=Mode.RECENT_N, recent_turns=99).summarize(msgs)
+        assert len(out) == len(msgs)
+
+    async def test_single_message_no_user_turn(self) -> None:
+        # History with no user message at all (e.g. a lone system/assistant note).
+        msgs = [{"role": "assistant", "content": "preamble"}]
+        out = await HistorySummarizer(mode=Mode.RECENT_N, recent_turns=1).summarize(msgs)
+        assert out == msgs
+
+    async def test_recent_turns_zero_keeps_nothing(self) -> None:
+        msgs = _convo(3)
+        out = await HistorySummarizer(mode=Mode.RECENT_N, recent_turns=0).summarize(msgs)
+        # "Keep the last 0 turns" must not retain the entire conversation.
+        assert _user_count(out) == 0
+
+    async def test_negative_recent_turns_does_not_crash(self) -> None:
+        msgs = _convo(3)
+        # A negative N is invalid input; it should be clamped/handled, not crash.
+        out = await HistorySummarizer(mode=Mode.RECENT_N, recent_turns=-100).summarize(msgs)
+        assert isinstance(out, list)
+
+
+# --------------------------------------------------------------------------- #
+# SUMMARY
+# --------------------------------------------------------------------------- #
+class TestSummaryMode:
+    async def test_summary_with_llm_collapses_to_one_message(self) -> None:
+        msgs = _convo(4)
+        llm = _FakeLLM(content="the gist")
+        out = await HistorySummarizer(mode=Mode.SUMMARY).summarize(msgs, llm_client=llm)
+        assert llm.calls == 1
+        assert len(out) == 1
+        assert "the gist" in out[0]["content"]
+
+    async def test_summary_without_llm_falls_back_to_text(self) -> None:
+        msgs = _convo(3)
+        out = await HistorySummarizer(mode=Mode.SUMMARY).summarize(msgs, llm_client=None)
+        assert len(out) == 1
+        # Text fallback embeds the original turns inline.
+        assert "q1" in out[0]["content"]
+
+    async def test_summary_llm_failure_falls_back_to_text(self) -> None:
+        msgs = _convo(3)
+        llm = _FakeLLM(raises=True)
+        out = await HistorySummarizer(mode=Mode.SUMMARY).summarize(msgs, llm_client=llm)
+        # LLM raised, but the handoff must still produce a usable summary.
+        assert len(out) == 1
+        assert "q1" in out[0]["content"]
+
+    async def test_summary_empty_history(self) -> None:
+        out = await HistorySummarizer(mode=Mode.SUMMARY).summarize([], llm_client=None)
+        assert out == []
+
+
+# --------------------------------------------------------------------------- #
+# HYBRID
+# --------------------------------------------------------------------------- #
+class TestHybridMode:
+    async def test_hybrid_summary_plus_recent(self) -> None:
+        msgs = _convo(5)
+        llm = _FakeLLM(content="older stuff")
+        out = await HistorySummarizer(mode=Mode.HYBRID, recent_turns=2).summarize(
+            msgs, llm_client=llm
+        )
+        # 1 summary message for the older 3 turns + the last 2 turns (4 messages).
+        assert out[0]["content"].find("older stuff") != -1
+        assert [m["content"] for m in out[-4:]] == ["q4", "a4", "q5", "a5"]
+
+    async def test_hybrid_n_covers_all_skips_summary(self) -> None:
+        # When recent_turns covers the whole history, boundary==0 -> no summary,
+        # full history returned verbatim.
+        msgs = _convo(2)
+        out = await HistorySummarizer(mode=Mode.HYBRID, recent_turns=10).summarize(msgs)
+        assert [m["content"] for m in out] == [m["content"] for m in msgs]
+
+    async def test_hybrid_zero_summarizes_everything(self) -> None:
+        msgs = _convo(3)
+        llm = _FakeLLM(content="summary")
+        out = await HistorySummarizer(mode=Mode.HYBRID, recent_turns=0).summarize(
+            msgs, llm_client=llm
+        )
+        # recent_turns=0 => keep 0 verbatim, so everything is summarized into 1 msg.
+        assert len(out) == 1
+
+
+# --------------------------------------------------------------------------- #
+# Sync wrapper parity (summarize_conversation) — same boundary engine
+# --------------------------------------------------------------------------- #
+class TestSyncWrapperParity:
+    def test_sync_recent_n_matches_async_semantics(self) -> None:
+        msgs = _convo(4)
+        out = summarize_conversation(msgs, Mode.RECENT_N, recent_turns=2)
+        assert [m["content"] for m in out] == ["q3", "a3", "q4", "a4"]
+
+    def test_sync_recent_n_zero_keeps_nothing(self) -> None:
+        msgs = _convo(3)
+        out = summarize_conversation(msgs, Mode.RECENT_N, recent_turns=0)
+        assert _user_count(out) == 0
+
+
+# --------------------------------------------------------------------------- #
+# Boundary engine, isolated
+# --------------------------------------------------------------------------- #
+class TestTurnBoundary:
+    def test_boundary_last_turn(self) -> None:
+        msgs = _convo(3)  # user indices 0,2,4
+        assert _find_turn_boundary(msgs, 1) == 4
+
+    def test_boundary_n_too_large_returns_zero(self) -> None:
+        msgs = _convo(2)
+        assert _find_turn_boundary(msgs, 99) == 0
+
+    def test_boundary_zero_should_be_end_of_history(self) -> None:
+        msgs = _convo(3)
+        # Keeping 0 turns means the boundary is at the very end (len), not the start.
+        assert _find_turn_boundary(msgs, 0) == len(msgs)

--- a/tests/unit/test_whitespace_user_id_journey.py
+++ b/tests/unit/test_whitespace_user_id_journey.py
@@ -306,3 +306,24 @@ class TestFullJourney:
 
         assert validate_user_id(WHITESPACE) is None, "whitespace → None at the boundary"
         assert validate_user_id(CLEAN_ID) == CLEAN_ID, "clean id survives validation"
+
+    def test_pipe_allowed_for_auth0_sub_claims(self):
+        """
+        PR #55 review follow-up: Auth0-style JWT 'sub' claims look like
+        'auth0|64abc...'. The pipe is not a Redis key delimiter here, so it is
+        safe to allow — these ids must pass validation unchanged. The colon
+        exclusion (the real delimiter) must still reject.
+        """
+        from continuum.utils.sanitization import (
+            InvalidIdentifierError,
+            validate_conversation_id,
+            validate_user_id,
+        )
+
+        auth0_id = "auth0|64abc123def456"
+        assert validate_user_id(auth0_id) == auth0_id, "Auth0 sub with '|' must be accepted"
+        assert validate_conversation_id(auth0_id) == auth0_id
+
+        # The colon delimiter must still be rejected (cross-tenant key safety).
+        with pytest.raises(InvalidIdentifierError):
+            validate_user_id("u:alice")


### PR DESCRIPTION
## Relates to
Feature: Agent core & workflows (handoffs / summarization).

## Problem
Two adversarial findings in the handoff path:

1. **agent_stack not popped on failed handoff (High).**
   `execute_handoff` always pushes the target, but the executor only popped it
   back when `return_to_parent=True`. A failed handoff with
   `return_to_parent=False` left the target stuck on `agent_stack`, which then
   tripped false cycle detection on retry (and inflated `agents_used`).
   Blast radius is one run (state is fresh per run), but it silently breaks
   retry/recovery in multi-agent flows. Not intentional — the existing
   `return_to_parent=True` branch already popped on failure; the False case
   was simply missed.

2. **recent_turns<=0 negative-index bug (Medium-High).**
   `_find_turn_boundary` hit `user_indices[-0]` (== index 0) when
   `recent_turns=0`, returning nearly the full history instead of none for
   RECENT_N / HYBRID summarization modes.

## Changes
- `agent/execution/executor.py` — failed handoff now pops the target whenever
  it is on top of the stack (i.e. it was actually pushed), regardless of
  `return_to_parent`. Early-check failures (depth/cycle/missing) never pushed,
  so they are correctly left alone.
- `agent/handoff/history.py` — `_find_turn_boundary` returns `len(messages)`
  for `recent_turns<=0` so the recent slice is empty.

## Tests (tests/integration/, @pytest.mark.integration)
- `test_handoff_stack_cleanup_adversarial.py` — failure leaves stack clean
  (return_to_parent False/True), and a retry of the same failed target is no
  longer blocked as a false cycle.
- `test_handoff_summarization_adversarial.py` — all four modes
  (FULL/SUMMARY/RECENT_N/HYBRID), recent_turns=0, N>len(history).
- `test_handoff_depth_adversarial.py` — depth limits, cycle detection,
  missing/unregistered target, diamond topology.
---
Also updated the allowed list for user_id in utils/sanitization.py as suggested in PR #55.