### PR TITLE
test: move adversarial handoff tests to tests/unit so CI runs them

### DIFF
--- a/tests/unit/test_handoff_depth_adversarial.py
+++ b/tests/unit/test_handoff_depth_adversarial.py
@@ -1,5 +1,5 @@
 """
-Adversarial integration tests for handoff depth limiting and cycle detection.
+Adversarial unit tests for handoff depth limiting and cycle detection.
 
 The story: agents can hand off to each other — triage → billing → refund etc.
 Every hand-off pushes a name onto agent_stack. The HandoffExecutor checks that
@@ -25,8 +25,6 @@ from types import SimpleNamespace
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
-import pytest
-
 from continuum.agent.base import BaseAgent
 from continuum.agent.execution.handoff_executor import HandoffExecutor
 from continuum.agent.handoff.manager import HandoffManager
@@ -35,9 +33,6 @@ from continuum.agent.types import (
     RunState,
     generate_run_id,
 )
-
-pytestmark = pytest.mark.integration
-
 
 # --------------------------------------------------------------------------- #
 # Helpers

--- a/tests/unit/test_handoff_stack_cleanup_adversarial.py
+++ b/tests/unit/test_handoff_stack_cleanup_adversarial.py
@@ -1,5 +1,5 @@
 """
-Adversarial integration tests for agent_stack cleanup on handoff FAILURE.
+Adversarial unit tests for agent_stack cleanup on handoff FAILURE.
 
 Issue under test:
     "agent_stack not popped on handoff failure → unbounded growth on repeated
@@ -35,16 +35,11 @@ from types import SimpleNamespace
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
-import pytest
-
 from continuum.agent.base import BaseAgent
 from continuum.agent.execution.executor import Executor
 from continuum.agent.execution.handoff_executor import HandoffExecutor
 from continuum.agent.handoff.manager import HandoffManager
 from continuum.agent.types import Handoff, RunContext, RunState, generate_run_id
-
-pytestmark = pytest.mark.integration
-
 
 # --------------------------------------------------------------------------- #
 # Helpers

--- a/tests/unit/test_handoff_summarization_adversarial.py
+++ b/tests/unit/test_handoff_summarization_adversarial.py
@@ -1,5 +1,5 @@
 """
-Adversarial integration tests for handoff history summarization.
+Adversarial unit tests for handoff history summarization.
 
 Covers the issue #25 requirement to exercise *every* summarization mode used when
 one agent hands off to another:
@@ -23,8 +23,7 @@ Hostile angles probed here:
   - deepcopy isolation: a returned message must not alias the input
 
 These are pure-Python paths (no external service), but the SUMMARY LLM path is
-driven with an injected fake async client so nothing real is contacted. Marked
-@pytest.mark.integration per the issue's deliverable convention.
+driven with an injected fake async client so nothing real is contacted.
 
 FIXED DEFECTS (these were originally asserted as xfail(strict=True); the fix in
 ``_find_turn_boundary`` guards ``n_turns <= 0`` by returning ``len(messages)``,
@@ -42,16 +41,12 @@ from __future__ import annotations
 from types import SimpleNamespace
 from typing import Any
 
-import pytest
-
 from continuum.agent.handoff.history import (
     HistorySummarizer,
     _find_turn_boundary,
     summarize_conversation,
 )
 from continuum.agent.types import HistorySummarizationMode as Mode
-
-pytestmark = pytest.mark.integration
 
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
## Why
The three adversarial handoff suites added in #60 (depth/cycle limiting, agent_stack cleanup on failed handoff, and history summarization) landed under `tests/integration/`. But CI's test job runs only:

```
pytest tests/unit --ignore-glob='tests/unit/test_issue*.py' -q
```

So those regression guards **never run in CI** — a future change could silently re-break the #60 fixes and CI would stay green.

## What
- Move all three files from `tests/integration/` → `tests/unit/` (git rename, history preserved).
- Drop the now-inaccurate `pytestmark = pytest.mark.integration` and the otherwise-unused `import pytest`.
- Minor docstring wording ("integration" → "unit").

**No test logic changed.** All three use mocks/stubs (no real LLM, Redis, or network), so they are unit tests by nature.

## Verification
- `pytest tests/unit/test_handoff_*adversarial.py` → **35 passed**
- `ruff check` + `ruff format --check` (0.14.10) → clean

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)