### PR TITLE
chore(release): 0.2.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ and Continuum adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 ## [Unreleased]
 
 ### Added
+- _Nothing yet._
+
+### Changed
+- _Nothing yet._
+
+### Fixed
+- _Nothing yet._
+
+---
+
+## [0.2.4] — 2026-06-26
+
+### Added
 - GitHub issue templates (`bug.yml`, `feature.yml`, `question.yml`) and a chooser config that disables blank issues and routes security reports to a private advisory.
 - Pull request template with Conventional-Commits typing, DCO checkbox, and lint/type/test gates.
 - `CODEOWNERS` for automatic review routing.
@@ -84,6 +97,9 @@ and Continuum adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 Initial public release. See the repository history for details prior to this changelog being introduced.
 
-[Unreleased]: https://github.com/shyftlabs/continuum/compare/v0.2.1...HEAD
+[Unreleased]: https://github.com/shyftlabs/continuum/compare/v0.2.4...HEAD
+[0.2.4]: https://github.com/shyftlabs/continuum/compare/v0.2.3...v0.2.4
+[0.2.3]: https://github.com/shyftlabs/continuum/compare/v0.2.2...v0.2.3
+[0.2.2]: https://github.com/shyftlabs/continuum/compare/v0.2.1...v0.2.2
 [0.2.1]: https://github.com/shyftlabs/continuum/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/shyftlabs/continuum/releases/tag/v0.2.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "shyftlabs-continuum"
-version = "0.2.3"
+version = "0.2.4"
 description = "Agentic Framework for Enterprise-Wide Execution with multi-LLM provider support, observability, and error tracking"
 readme = "README.md"
 requires-python = ">=3.13"


### PR DESCRIPTION
## What

Release prep for **0.2.4**: bump `version` in `pyproject.toml` (`0.2.3` → `0.2.4`) and roll the accumulated `## [Unreleased]` changelog entries into `## [0.2.4] — 2026-06-26`.

## Why

The README PyPI-rendering fix (#66) is merged in `dev` but **not visible on the pip page** — PyPI version pages are immutable, so the fix only ships with a new version number. This bump is the vehicle that publishes it (and the other unreleased changes) to PyPI.

## How tested

- `grep` confirms `version = "0.2.4"` in `pyproject.toml` (the single source of truth; `continuum.__version__` reads it from metadata, no other file to touch).
- CHANGELOG: fresh empty `[Unreleased]`, entries stamped under `[0.2.4]`, and compare-links backfilled for `0.2.2`–`0.2.4` (were previously missing).
- No source code changed.

## Type of change

- [x] `chore` — refactor / deps / tooling (release)

## Checklist

- [x] PR targets `dev` (not `main`)
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Every commit is signed off (`git commit -s`) per the [DCO](https://developercertificate.org)
- [ ] `pytest` passes locally — n/a, no code changed (CI will run it)
- [ ] `ruff check .` passes — n/a, no code changed
- [ ] `mypy` clean for changed code — n/a, no code changed
- [ ] Tests added or updated — n/a, release metadata only
- [x] Docs updated if user-facing (CHANGELOG)
- [x] `CHANGELOG.md` entry added
- [x] No secrets, credentials, or `.env` files committed

## After this merges (maintainer release steps)

1. Open the `dev → main` release PR (carries 0.2.4 + the README fix to `main`).
2. Tag the merged commit `v0.2.4` and publish a GitHub Release.
3. `release.yml` verifies the tag matches `pyproject.toml` and publishes to PyPI via OIDC.

> ⚠️ Note for reviewer: the `[Unreleased]` block was moved wholesale into `[0.2.4]`. A few entries (e.g. the `continuum` CLI) may have partially shipped in `0.2.1`–`0.2.3` already; please confirm the attribution is acceptable or trim as needed.
