### PR TITLE
fix(session): correct Redis TLS pool config + report real probe failure cause

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -156,3 +156,6 @@ extensions/
 
 # claude-flow runtime lock (per-session state, not source)
 .claude/scheduled_tasks.lock
+
+# Redis TLS test certs (generated locally by tests/integration/redis_tls/gen_certs.sh — never commit)
+tests/integration/redis_tls/certs/

--- a/src/continuum/config.py
+++ b/src/continuum/config.py
@@ -189,6 +189,15 @@ class Settings(BaseSettings):
     session_redis_password: str | None = None  # Redis password (matches docker-compose default)
     session_redis_db: int = 0  # Redis database number
     session_redis_ssl: bool = False  # Enable SSL/TLS for Redis
+    # TLS certificate verification policy, passed through to redis-py's
+    # SSLConnection only when set. None (default) => omit the kwarg => redis-py's
+    # verifying default ('required'). Managed endpoints (ElastiCache) need
+    # nothing here. Set 'none'/'optional' only for self-signed / private-CA test
+    # endpoints. NOTE: passing 'none' disables verification — opt-in, never default.
+    session_redis_ssl_cert_reqs: str | None = None
+    # Path to a CA bundle for verifying the Redis server cert. None (default) =>
+    # omit the kwarg => redis-py uses the system CA store. Set for private-CA endpoints.
+    session_redis_ssl_ca_certs: str | None = None
     session_redis_max_connections: int = (
         10  # Redis pool size (configurable via env; floored at the safe minimum)
     )

--- a/src/continuum/connectors/redis.py
+++ b/src/continuum/connectors/redis.py
@@ -89,7 +89,18 @@ class RedisConnector(BaseConnector["Redis"]):
             "timeout": 5,
         }
         if self._config.redis_ssl:
-            conn_kwargs["ssl"] = True
+            # A pool selects TLS via connection_class=SSLConnection — NOT an
+            # `ssl=True` kwarg. `ssl=True` is a convenience only on redis.Redis()/
+            # from_url(); forwarded to a pool it reaches AbstractConnection.__init__
+            # and raises TypeError lazily on first command (S-TLS).
+            conn_kwargs["connection_class"] = redis.SSLConnection
+            # Pass cert knobs ONLY when explicitly set. Passing ssl_cert_reqs=None
+            # would map to CERT_NONE (verification OFF); omitting it keeps redis-py's
+            # verifying default ('required'). ssl_ca_certs=None means system CA store.
+            if self._config.redis_ssl_cert_reqs is not None:
+                conn_kwargs["ssl_cert_reqs"] = self._config.redis_ssl_cert_reqs
+            if self._config.redis_ssl_ca_certs is not None:
+                conn_kwargs["ssl_ca_certs"] = self._config.redis_ssl_ca_certs
 
         self._pool = redis.BlockingConnectionPool(**conn_kwargs)
         self._client = redis.Redis(connection_pool=self._pool, decode_responses=True)

--- a/src/continuum/infra/docker-compose.yml
+++ b/src/continuum/infra/docker-compose.yml
@@ -173,6 +173,37 @@ services:
     networks:
       - orchestrator-network
 
+  # TLS-enabled Redis for exercising the SSL session path (S-TLS regression).
+  # Opt-in only — start with:  docker compose --profile tls-test up redis-sdk-tls
+  # Certs are generated (git-ignored) by tests/integration/redis_tls/gen_certs.sh.
+  redis-sdk-tls:
+    profiles: ["tls-test"]
+    image: docker.io/redis:7
+    container_name: orchestrator-redis-sdk-tls
+    restart: unless-stopped
+    command: >
+      redis-server
+      --port 0
+      --tls-port 6379
+      --tls-cert-file /certs/redis.crt
+      --tls-key-file /certs/redis.key
+      --tls-ca-cert-file /certs/ca.crt
+      --tls-auth-clients no
+      --maxmemory-policy noeviction
+      --maxmemory 256mb
+    ports:
+      - "${SESSION_REDIS_TLS_PORT:-6381}:6379"
+    volumes:
+      - ../../../tests/integration/redis_tls/certs:/certs:ro
+    healthcheck:
+      test: ["CMD", "sh", "-c", "redis-cli --tls --cert /certs/redis.crt --key /certs/redis.key --cacert /certs/ca.crt ping"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+      start_period: 5s
+    networks:
+      - orchestrator-network
+
   postgres:
     profiles: ["standard", "full"]
     image: docker.io/postgres:${POSTGRES_VERSION:-17}

--- a/src/continuum/session/client.py
+++ b/src/continuum/session/client.py
@@ -257,7 +257,12 @@ class SessionClient:
             self._emit_degraded_metric(False)
             return redis_provider
 
-        return self._fallback_or_fail("Redis is unreachable")
+        # Prefer the concrete cause the probe recorded (auth/TLS/config error);
+        # fall back to the generic wording only when none was supplied.
+        reason = getattr(redis_provider, "last_probe_error", None)
+        return self._fallback_or_fail(
+            f"Redis probe failed: {reason}" if reason else "Redis is unreachable"
+        )
 
     def _fallback_or_fail(self, reason: str) -> BaseSessionProvider:
         """Apply the configured fallback policy when Redis is unavailable.

--- a/src/continuum/session/config.py
+++ b/src/continuum/session/config.py
@@ -79,6 +79,21 @@ class SessionConfig(BaseModel):
         default_factory=lambda: settings.session_redis_ssl,
         description="Enable SSL/TLS for Redis",
     )
+    redis_ssl_cert_reqs: str | None = Field(
+        default_factory=lambda: settings.session_redis_ssl_cert_reqs,
+        description=(
+            "TLS cert verification policy passed to redis-py's SSLConnection "
+            "only when set. None => redis-py's verifying default ('required'). "
+            "'none' disables verification (opt-in, for self-signed test endpoints)."
+        ),
+    )
+    redis_ssl_ca_certs: str | None = Field(
+        default_factory=lambda: settings.session_redis_ssl_ca_certs,
+        description=(
+            "Path to a CA bundle for verifying the Redis server cert. "
+            "None => system CA store. Set for private-CA endpoints."
+        ),
+    )
 
     # Connection Pool Configuration
     redis_max_connections: int = Field(

--- a/src/continuum/session/providers/redis.py
+++ b/src/continuum/session/providers/redis.py
@@ -83,6 +83,9 @@ class RedisSessionProvider(BaseSessionProvider):
         self._connector = RedisConnector(config)
         self._initialized = False
         self._lock = threading.Lock()
+        # Reason the most recent aping() failed (None on success). Lets the
+        # SessionClient report the real cause instead of a generic "unreachable".
+        self._last_probe_error: str | None = None
 
         if auto_initialize:
             self.initialize()
@@ -101,6 +104,15 @@ class RedisSessionProvider(BaseSessionProvider):
     def is_initialized(self) -> bool:
         """Check if the provider is initialized and ready."""
         return self._config.enabled and self._initialized and self._redis is not None
+
+    @property
+    def last_probe_error(self) -> str | None:
+        """Reason the most recent aping() failed, or None if it succeeded.
+
+        Lets the SessionClient report the actual cause (auth error, TLS handshake,
+        bad config) instead of a blanket 'Redis is unreachable'.
+        """
+        return self._last_probe_error
 
     def initialize(self) -> bool:
         """
@@ -172,10 +184,16 @@ class RedisSessionProvider(BaseSessionProvider):
             if not self._initialized:
                 self.initialize()
             if self._redis is None:
+                self._last_probe_error = (
+                    "Redis client not initialized (sessions disabled or misconfigured)"
+                )
                 return False
             await self._redis.ping()
+            self._last_probe_error = None  # success clears any prior reason
             return True
-        except Exception:
+        except Exception as e:  # contract preserved: probe never raises
+            self._last_probe_error = f"{type(e).__name__}: {e}"
+            logger.debug("Redis session probe failed: %s", self._last_probe_error)
             return False
 
     def _ensure_enabled(self) -> None:

--- a/tests/integration/redis_tls/gen_certs.sh
+++ b/tests/integration/redis_tls/gen_certs.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Generate a self-signed CA + server cert for the redis-sdk-tls test service.
+#
+# Output (all git-ignored, NEVER commit): tests/integration/redis_tls/certs/
+#   ca.crt / ca.key       — local test CA
+#   redis.crt / redis.key — server cert signed by that CA (CN/SAN = localhost)
+#
+# Usage:
+#   tests/integration/redis_tls/gen_certs.sh
+#   docker compose --profile tls-test up redis-sdk-tls
+#   pytest tests/integration/test_redis_session_tls.py
+set -euo pipefail
+
+CERT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/certs"
+mkdir -p "$CERT_DIR"
+cd "$CERT_DIR"
+
+# 1) Local test CA
+openssl genrsa -out ca.key 4096
+openssl req -x509 -new -nodes -key ca.key -sha256 -days 3650 \
+  -subj "/CN=continuum-test-ca" -out ca.crt
+
+# 2) Server key + CSR (localhost, with SAN so hostname verification passes)
+openssl genrsa -out redis.key 2048
+openssl req -new -key redis.key -subj "/CN=localhost" -out redis.csr
+
+# 3) Sign the server cert with the CA
+openssl x509 -req -in redis.csr -CA ca.crt -CAkey ca.key -CAcreateserial \
+  -out redis.crt -days 825 -sha256 \
+  -extfile <(printf "subjectAltName=DNS:localhost,IP:127.0.0.1")
+
+rm -f redis.csr ca.srl
+chmod 644 ./*.crt ./*.key  # redis container reads them read-only
+echo "Certs written to $CERT_DIR"

--- a/tests/integration/test_redis_session_tls.py
+++ b/tests/integration/test_redis_session_tls.py
@@ -1,0 +1,80 @@
+"""
+Integration test for the TLS Redis session path (S-TLS regression).
+
+Guards the bug where TLS was requested via an `ssl=True` pool kwarg, which
+redis-py forwards to AbstractConnection and rejects with TypeError on the first
+command — silently degrading every TLS deployment to the in-memory fallback.
+
+Requires the opt-in TLS Redis service and generated certs:
+
+    tests/integration/redis_tls/gen_certs.sh
+    docker compose --profile tls-test up -d redis-sdk-tls
+    pytest tests/integration/test_redis_session_tls.py
+
+Skips cleanly (never fails) when the certs or the TLS service are absent.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.integration
+
+_CA_CERT = Path(__file__).parent / "redis_tls" / "certs" / "ca.crt"
+_TLS_PORT = 6381
+
+
+@pytest.fixture
+async def tls_session_provider():
+    if not _CA_CERT.exists():
+        pytest.skip(
+            "TLS certs missing — run tests/integration/redis_tls/gen_certs.sh "
+            "and start `docker compose --profile tls-test up redis-sdk-tls`."
+        )
+
+    from continuum.session.config import SessionConfig
+    from continuum.session.providers.redis import RedisSessionProvider
+
+    config = SessionConfig(
+        enabled=True,
+        redis_host="localhost",
+        redis_port=_TLS_PORT,
+        redis_ssl=True,
+        # Verify against the local test CA (default 'required' cert_reqs is kept).
+        redis_ssl_ca_certs=str(_CA_CERT),
+        ttl_seconds=300,
+        max_messages=100,
+    )
+    provider = RedisSessionProvider(config=config)
+    provider.initialize()
+    # Probe over TLS; skip (not fail) if the opt-in service isn't up.
+    if not await provider.aping():
+        await provider.close()
+        pytest.skip("TLS Redis not reachable on :6381 (start the tls-test profile).")
+    yield provider
+    await provider.close()
+
+
+class TestRedisSessionTLS:
+    async def test_tls_round_trip_persists(self, tls_session_provider, test_id):
+        """A full create → add → read cycle must work over TLS (no TypeError,
+        no silent in-memory degrade)."""
+        from continuum.session.types import ChatMessage
+
+        sid = await tls_session_provider.get_or_create_session(
+            session_id=f"tls-sess-{test_id}", user_id="tls-user"
+        )
+        await tls_session_provider.add_message(sid, ChatMessage(role="user", content="over TLS"))
+        messages = await tls_session_provider.get_messages(sid)
+
+        assert [m.content for m in messages] == ["over TLS"]
+
+    async def test_pool_uses_ssl_connection(self, tls_session_provider):
+        """The live client must be backed by an SSLConnection pool — proving TLS
+        is actually negotiated, not silently dropped to plaintext."""
+        from redis.asyncio.connection import SSLConnection
+
+        pool = tls_session_provider._redis.connection_pool
+        assert pool.connection_class is SSLConnection

--- a/tests/unit/test_connector_redis.py
+++ b/tests/unit/test_connector_redis.py
@@ -8,6 +8,8 @@ from __future__ import annotations
 
 from unittest.mock import AsyncMock, MagicMock
 
+from redis.asyncio.connection import Connection, SSLConnection
+
 from continuum.connectors.base import ConnectionMode
 from continuum.connectors.redis import RedisConnector
 from continuum.session.config import SessionConfig
@@ -76,6 +78,104 @@ class TestDescribeMasksSecrets:
         assert d["name"] == "redis"
         assert d["host"] == "localhost"
         assert "supersecret" not in str(d)
+
+
+class TestTlsConnection:
+    """Regression: a pool selects TLS via connection_class=SSLConnection, not an
+    `ssl=True` kwarg. Passing `ssl=True` to the pool reaches AbstractConnection
+    and raises TypeError lazily on first command (S-TLS). Also guards the cert
+    verification default from silently weakening.
+    """
+
+    def test_tls_uses_ssl_connection_class(self):
+        c = RedisConnector(SessionConfig(enabled=True, redis_host="my.redis.cloud", redis_ssl=True))
+        pool = c.build_client().connection_pool
+        assert pool.connection_class is SSLConnection
+
+    def test_tls_connection_object_builds_without_typeerror(self):
+        # The original bug surfaced lazily when the pool first built a connection.
+        c = RedisConnector(SessionConfig(enabled=True, redis_host="my.redis.cloud", redis_ssl=True))
+        pool = c.build_client().connection_pool
+        conn = pool.connection_class(**pool.connection_kwargs)  # must not raise
+        assert isinstance(conn, SSLConnection)
+        # No stray `ssl` kwarg leaked into connection_kwargs.
+        assert "ssl" not in pool.connection_kwargs
+
+    def test_non_tls_path_untouched(self):
+        c = RedisConnector(SessionConfig(enabled=True, redis_host="10.0.0.5", redis_ssl=False))
+        pool = c.build_client().connection_pool
+        assert pool.connection_class is Connection
+        assert "ssl" not in pool.connection_kwargs
+        assert "ssl_cert_reqs" not in pool.connection_kwargs
+
+    def test_cert_kwargs_omitted_when_unset(self):
+        # Default (None) must NOT pass ssl_cert_reqs=None (which maps to CERT_NONE,
+        # disabling verification). Omitting keeps redis-py's verifying default.
+        c = RedisConnector(SessionConfig(enabled=True, redis_host="my.redis.cloud", redis_ssl=True))
+        kwargs = c.build_client().connection_pool.connection_kwargs
+        assert "ssl_cert_reqs" not in kwargs
+        assert "ssl_ca_certs" not in kwargs
+
+    def test_cert_kwargs_passed_through_when_set(self):
+        c = RedisConnector(
+            SessionConfig(
+                enabled=True,
+                redis_host="my.redis.cloud",
+                redis_ssl=True,
+                redis_ssl_cert_reqs="none",
+                redis_ssl_ca_certs="/etc/ssl/my-ca.pem",
+            )
+        )
+        kwargs = c.build_client().connection_pool.connection_kwargs
+        assert kwargs["ssl_cert_reqs"] == "none"
+        assert kwargs["ssl_ca_certs"] == "/etc/ssl/my-ca.pem"
+
+
+class TestProviderProbeReason:
+    """The session provider's aping() records WHY it failed (last_probe_error) so
+    the caller can report the real cause instead of a generic 'unreachable'. The
+    never-raise bool contract is preserved.
+    """
+
+    def _provider(self):
+        from continuum.session.providers.redis import RedisSessionProvider
+
+        return RedisSessionProvider(
+            SessionConfig(enabled=True, redis_host="localhost", redis_port=6380),
+            auto_initialize=True,
+        )
+
+    async def test_success_clears_reason(self, monkeypatch):
+        p = self._provider()
+        p._redis = MagicMock()
+        p._redis.ping = AsyncMock(return_value=True)
+        assert await p.aping() is True
+        assert p.last_probe_error is None
+
+    async def test_failure_records_reason(self, monkeypatch):
+        p = self._provider()
+        p._redis = MagicMock()
+        p._redis.ping = AsyncMock(side_effect=ValueError("WRONGPASS bad auth"))
+        assert await p.aping() is False  # never raises
+        assert p.last_probe_error is not None
+        assert "ValueError" in p.last_probe_error
+        assert "WRONGPASS" in p.last_probe_error
+
+    async def test_prior_error_cleared_on_later_success(self):
+        p = self._provider()
+        p._redis = MagicMock()
+        p._redis.ping = AsyncMock(side_effect=ValueError("boom"))
+        await p.aping()
+        assert p.last_probe_error is not None
+        p._redis.ping = AsyncMock(return_value=True)
+        await p.aping()
+        assert p.last_probe_error is None
+
+    async def test_none_client_sets_reason(self):
+        p = self._provider()
+        p._redis = None
+        assert await p.aping() is False
+        assert p.last_probe_error is not None
 
 
 class TestProviderUsesConnector:

--- a/tests/unit/test_session_probe_reason.py
+++ b/tests/unit/test_session_probe_reason.py
@@ -1,0 +1,90 @@
+"""
+When the Redis connectivity probe fails, the SessionClient must report the
+ACTUAL cause (auth error, TLS handshake, bad config, ...) captured by the
+provider's ``last_probe_error`` — not a blanket "Redis is unreachable", which
+mislabels every config/setup failure as a network outage.
+
+Mock-first unit tests — no live Redis. They pin the fallback *message* while
+leaving the degrade/fail decision (governed by fallback_mode) unchanged.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from continuum.session.client import SessionClient
+from continuum.session.config import SessionConfig
+from continuum.session.exceptions import SessionConnectionError
+
+
+def _spy_client_logger(monkeypatch) -> MagicMock:
+    spy = MagicMock()
+    monkeypatch.setattr("continuum.session.client.logger", spy)
+    return spy
+
+
+def _patch_provider(monkeypatch, *, reachable: bool, reason: str | None) -> None:
+    """Make RedisSessionProvider.aping() report the given reachability + reason."""
+    monkeypatch.setattr(
+        "continuum.session.providers.redis.RedisSessionProvider.aping",
+        AsyncMock(return_value=reachable),
+        raising=False,
+    )
+    # last_probe_error is a property on the class; override with a plain attribute
+    # value for the test by patching the property to return our reason.
+    monkeypatch.setattr(
+        "continuum.session.providers.redis.RedisSessionProvider.last_probe_error",
+        property(lambda self: reason),
+        raising=False,
+    )
+
+
+class TestFallbackMessageReportsCause:
+    async def test_captured_reason_appears_in_fail_message(self, monkeypatch):
+        # fallback_mode='fail' surfaces the reason as a raised error we can assert on.
+        _patch_provider(
+            monkeypatch, reachable=False, reason="AuthenticationError: WRONGPASS invalid password"
+        )
+        cfg = SessionConfig(
+            enabled=True, redis_host="localhost", redis_port=6380, fallback_mode="fail"
+        )
+        client = SessionClient(session_config=cfg, auto_initialize=False)
+
+        with pytest.raises(SessionConnectionError) as ei:
+            await client.get_or_create_session(user_id="alice")
+        msg = str(ei.value)
+        assert "AuthenticationError" in msg
+        assert "WRONGPASS" in msg
+        assert "unreachable" not in msg.lower()
+
+    async def test_missing_reason_falls_back_to_generic(self, monkeypatch):
+        # Provider exposes no reason (None) -> keep the generic wording (back-compat).
+        _patch_provider(monkeypatch, reachable=False, reason=None)
+        cfg = SessionConfig(
+            enabled=True, redis_host="localhost", redis_port=6380, fallback_mode="fail"
+        )
+        client = SessionClient(session_config=cfg, auto_initialize=False)
+
+        with pytest.raises(SessionConnectionError) as ei:
+            await client.get_or_create_session(user_id="alice")
+        assert "unreachable" in str(ei.value).lower()
+
+    async def test_reachable_returns_redis_provider(self, monkeypatch):
+        # Happy path unchanged: reachable -> real Redis provider, no fallback.
+        _patch_provider(monkeypatch, reachable=True, reason=None)
+        op = AsyncMock(return_value="sess-1")
+        monkeypatch.setattr(
+            "continuum.session.providers.redis.RedisSessionProvider.get_or_create_session",
+            op,
+            raising=True,
+        )
+        cfg = SessionConfig(enabled=True, redis_host="localhost", redis_port=6380)
+        client = SessionClient(session_config=cfg, auto_initialize=False)
+
+        sid = await client.get_or_create_session(user_id="alice")
+        assert sid == "sess-1"
+        from continuum.session.providers.redis import RedisSessionProvider
+
+        assert isinstance(client._provider, RedisSessionProvider)


### PR DESCRIPTION
## Summary

Two related session-persistence fixes for TLS / managed Redis (e.g. ElastiCache).

### 1. Redis TLS connection bug (silent data loss)
`RedisConnector` selected TLS via an `ssl=True` pool kwarg. redis-py's `BlockingConnectionPool` doesn't accept `ssl` — it forwards it to `AbstractConnection`, which raises `TypeError` **lazily on the first command**. Init "succeeded", then every TLS session read/write died and **silently degraded to the in-memory store** — conversation history + tool-context persistence lost, reported misleadingly as *"Redis is unreachable"*. Seen in prod on a TLS ElastiCache endpoint.

**Fix:** select TLS via `connection_class=SSLConnection`, with **conditional** passthrough for `ssl_cert_reqs` / `ssl_ca_certs` (inserted only when explicitly set, so the verifying default is never silently weakened to `CERT_NONE`). New optional settings `session_redis_ssl_cert_reqs` / `session_redis_ssl_ca_certs` (default `None` = existing behavior). **Backward compatible** — existing OpenAI/managed-cert deployments are unaffected and still verify.

### 2. Honest probe-failure reporting
The connectivity probe swallowed every error and the caller hardcoded `"Redis is unreachable"`, mislabeling auth / TLS / config errors as network outages (which is what masked bug #1). `RedisSessionProvider.aping()` now records `last_probe_error` (and logs it at debug); `SessionClient` reports the captured cause. The never-raise `aping()` bool contract (shared by 5 other connectors) is unchanged.

## Tests
- **12 new unit tests**: TLS pool selection (`connection_class=SSLConnection`, no `ssl` leak, non-TLS path untouched), cert-default safety (omitted-when-`None`, passed-when-set), probe reason capture/clear, and caller message reporting.
- **Opt-in TLS integration test** (`tests/integration/test_redis_session_tls.py`) with a `tls-test` docker-compose service and a git-ignored cert generator; skips cleanly when the service/certs are absent.

## Check status (verified locally against `.github/workflows/ci.yml`)
- **CI/Lint**: `ruff check .` ✅ and `ruff format --check .` (361 files) ✅
- **CI/Tests**: `pytest tests/unit --ignore-glob='tests/unit/test_issue*.py'` → 1111 passed, 0 failed ✅

> Note: the repo's full unit run shows 4 failures in `tests/unit/test_issue*.py` — these are **pre-existing** (verified identical on a pristine tree) legacy tests using `asyncio.get_event_loop()`, which is fragile under Python 3.13 test ordering. They are unrelated to this change and are already excluded by the CI test command. Worth a separate cleanup ticket.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)