### PR TITLE
fix(test): generate OpenSSL 3.x-valid CA in redis TLS gen_certs.sh

### DIFF
--- a/tests/integration/redis_tls/gen_certs.sh
+++ b/tests/integration/redis_tls/gen_certs.sh
@@ -16,18 +16,27 @@ mkdir -p "$CERT_DIR"
 cd "$CERT_DIR"
 
 # 1) Local test CA
+#    basicConstraints:CA + keyUsage:keyCertSign are REQUIRED — without them
+#    OpenSSL 3.x rejects the CA at verify time ("CA cert does not include key
+#    usage extension"), which makes the TLS integration test silently SKIP
+#    (the client can't verify the chain, so the fixture treats Redis as
+#    unreachable). Older OpenSSL was lenient; 3.x is not.
 openssl genrsa -out ca.key 4096
 openssl req -x509 -new -nodes -key ca.key -sha256 -days 3650 \
-  -subj "/CN=continuum-test-ca" -out ca.crt
+  -subj "/CN=continuum-test-ca" \
+  -addext "basicConstraints=critical,CA:TRUE" \
+  -addext "keyUsage=critical,keyCertSign,cRLSign" \
+  -out ca.crt
 
 # 2) Server key + CSR (localhost, with SAN so hostname verification passes)
 openssl genrsa -out redis.key 2048
 openssl req -new -key redis.key -subj "/CN=localhost" -out redis.csr
 
-# 3) Sign the server cert with the CA
+# 3) Sign the server cert with the CA (SAN + serverAuth EKU so strict TLS
+#    clients accept it under OpenSSL 3.x)
 openssl x509 -req -in redis.csr -CA ca.crt -CAkey ca.key -CAcreateserial \
   -out redis.crt -days 825 -sha256 \
-  -extfile <(printf "subjectAltName=DNS:localhost,IP:127.0.0.1")
+  -extfile <(printf "subjectAltName=DNS:localhost,IP:127.0.0.1\nkeyUsage=critical,digitalSignature,keyEncipherment\nextendedKeyUsage=serverAuth")
 
 rm -f redis.csr ca.srl
 chmod 644 ./*.crt ./*.key  # redis container reads them read-only


### PR DESCRIPTION
## What
`tests/integration/redis_tls/gen_certs.sh` created the self-signed CA **without** `basicConstraints`/`keyUsage` extensions. OpenSSL 3.x rejects such a CA at verify time:

```
[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: CA cert does not include key usage extension
```

Because the TLS client can't verify the chain, `test_redis_session_tls.py`'s fixture treats Redis as unreachable and **SKIPS** both tests. So the integration test that guards the `ssl=True` TLS regression **was not actually executing** on any modern-OpenSSL machine or CI — it just showed as skipped/green.

## Fix
- CA now carries `basicConstraints=critical,CA:TRUE` and `keyUsage=critical,keyCertSign,cRLSign`.
- Leaf cert gets `keyUsage=digitalSignature,keyEncipherment` + `extendedKeyUsage=serverAuth`.

## Verified
Regenerated certs with the patched script and ran the suite against `redis-sdk-tls`:
```
tests/integration/test_redis_session_tls.py .. 2 passed   (was: 2 skipped)
```
No source changes — the SSLConnection fix itself was already correct; this just makes its integration test actually run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
