### PR TITLE
fix(agent): default run-state persistence off via `PERSIST_RUN_STATE`

### DIFF
--- a/docs/agent.md
+++ b/docs/agent.md
@@ -268,7 +268,7 @@ All importable from `continuum.agent`.
 |---|---|---|
 | `default_max_turns` | `int` | `25` |
 | `default_timeout` | `int` | `300` |
-| `persist_state` | `bool` | `True` |
+| `persist_state` | `bool` | `False` (env `PERSIST_RUN_STATE`) |
 | `state_ttl` | `int` | `86400` |
 | `parallel_tool_calls` | `bool` | `True` |
 | `max_parallel_tools` | `int` | `5` |
@@ -617,10 +617,15 @@ if you want to drive handoffs manually.
 `from continuum.agent import RunStateManager,
 get_global_state_manager, initialize_global_state_manager`
 
-If `RunnerConfig.persist_state=True` (default), `RunState` is written to
-Redis with TTL `state_ttl`. This lets you pause/resume long runs (e.g.
-a workflow waiting on tool output) across processes. The default state
-manager uses the same Redis instance configured for sessions.
+If `RunnerConfig.persist_state=True`, `RunState` is written to Redis with
+TTL `state_ttl`. This is intended to support pause/resume of long runs
+(e.g. a workflow waiting on tool output) across processes. The default
+state manager uses the same Redis instance configured for sessions.
+
+Disabled by default (`persist_state=False`) — enable it globally with the
+`PERSIST_RUN_STATE` env flag, or per-runner by passing `persist_state=True`.
+Leaving it off avoids a Redis write (and a connection attempt when Redis is
+unavailable) on every run.
 
 ---
 

--- a/playground/data-label-clinic/agent.py
+++ b/playground/data-label-clinic/agent.py
@@ -79,7 +79,7 @@ class ClinicAgent:
         self._runner = AgentRunner(
             container=self._container,
             tool_executor=self._tool_executor,
-            config=RunnerConfig(persist_state=False, default_max_turns=self.config.max_turns),
+            config=RunnerConfig(default_max_turns=self.config.max_turns),
         )
         self._runner.register_agent(self._agent)
         self._initialized = True

--- a/playground/decision-trace-timetravel/web.py
+++ b/playground/decision-trace-timetravel/web.py
@@ -120,7 +120,7 @@ async def _startup() -> None:
         state.runner = AgentRunner(
             container=state.container,
             tool_executor=state.tool_executor,
-            config=RunnerConfig(persist_state=False, default_max_turns=default_config.max_turns),
+            config=RunnerConfig(default_max_turns=default_config.max_turns),
         )
         # Build all three topologies; register every concrete agent on the runner.
         m = default_config.model

--- a/playground/gateway-local-shop/agent.py
+++ b/playground/gateway-local-shop/agent.py
@@ -118,7 +118,7 @@ class LocalShopAgent:
         self._runner = AgentRunner(
             container=self._container,
             tool_executor=self._tool_executor,
-            config=RunnerConfig(persist_state=False, default_max_turns=self.config.max_turns),
+            config=RunnerConfig(default_max_turns=self.config.max_turns),
         )
         self._runner.register_agent(self._agent)
         self._initialized = True

--- a/playground/gateway-local-shop/test.py
+++ b/playground/gateway-local-shop/test.py
@@ -94,7 +94,7 @@ async def main() -> None:
 
     runner = AgentRunner(
         container=container,
-        config=RunnerConfig(persist_state=False, default_max_turns=5),
+        config=RunnerConfig(default_max_turns=5),
     )
 
     # ------------------------------------------------------------------

--- a/playground/gateway-multi-agent-shop/workflows.py
+++ b/playground/gateway-multi-agent-shop/workflows.py
@@ -103,7 +103,7 @@ class _BaseWorkflow:
         self._runner = AgentRunner(
             container=self._container,
             tool_executor=self._tool_executor,
-            config=RunnerConfig(persist_state=False, default_max_turns=self.config.max_turns),
+            config=RunnerConfig(default_max_turns=self.config.max_turns),
         )
         self._initialized = True
         logger.info(

--- a/playground/temporal-leadflow/temporal/worker.py
+++ b/playground/temporal-leadflow/temporal/worker.py
@@ -80,7 +80,7 @@ async def setup_registry(config: LeadFlowConfig | None = None) -> AgentRegistry:
     def _runner_factory():
         return AgentRunner(
             agent_registry=all_agents,
-            config=RunnerConfig(persist_state=False, default_max_turns=cfg.max_turns),
+            config=RunnerConfig(default_max_turns=cfg.max_turns),
         )
 
     registry.set_runner_factory(_runner_factory)

--- a/src/continuum/agent/config.py
+++ b/src/continuum/agent/config.py
@@ -321,7 +321,9 @@ class RunnerConfig:
     default_timeout: int = 300
 
     # State persistence
-    persist_state: bool = True  # Persist run state to Redis
+    # Defaults to the PERSIST_RUN_STATE env flag (off unless explicitly enabled).
+    # Callers can still override per-runner by passing persist_state=True/False.
+    persist_state: bool = field(default_factory=lambda: settings.persist_run_state)
     state_ttl: int = 3600 * 24  # State TTL in seconds (24 hours)
 
     # Tool execution

--- a/src/continuum/config.py
+++ b/src/continuum/config.py
@@ -277,6 +277,16 @@ class Settings(BaseSettings):
     decision_trace_checkpoint: bool = False
 
     # -------------------------------------------------------------------------
+    # Run-State Persistence Configuration
+    # -------------------------------------------------------------------------
+    # Write per-run state (RunState) to Redis on start/finish, intended for a
+    # future pause/resume/recovery feature. Reuses the session Redis instance.
+    # Off by default: nothing currently reads this data back, so enabling it only
+    # adds Redis writes (and a connection attempt when Redis is unavailable).
+    # Turn on via PERSIST_RUN_STATE when a consumer of run-state actually exists.
+    persist_run_state: bool = False  # PERSIST_RUN_STATE
+
+    # -------------------------------------------------------------------------
     # Lifecycle Configuration (Shutdown Behavior)
     # -------------------------------------------------------------------------
     shared_services_enabled: bool = (

--- a/tests/unit/test_persist_state_default.py
+++ b/tests/unit/test_persist_state_default.py
@@ -1,0 +1,99 @@
+"""
+Tests for run-state persistence defaulting to OFF via the PERSIST_RUN_STATE flag.
+
+Background: run-state persistence (RunnerConfig.persist_state) writes RunState to
+Redis on every run, for a future pause/resume feature that is not yet implemented
+(nothing reads the data back). It used to default to True with no env control, so
+every integrator had to disable it by hand. It now defaults to the PERSIST_RUN_STATE
+env flag, which is off unless explicitly enabled.
+
+Two layers are covered:
+  1. Config: the Settings default is off; the env flag flips it; RunnerConfig's
+     default tracks settings; an explicit per-runner override still wins.
+  2. Behavior: with persist_state off, ContextService never calls the state
+     manager's save() (no Redis write / connection attempt); with it on, it does.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from continuum.agent.config import RunnerConfig
+from continuum.agent.services.context_service import ContextService
+
+# ---------------------------------------------------------------------------
+# 1. Config-level behavior
+# ---------------------------------------------------------------------------
+
+
+class TestPersistStateConfig:
+    def test_settings_default_is_off(self, monkeypatch):
+        # The Settings *default* (no env override) is False.
+        from continuum.config import Settings
+
+        monkeypatch.delenv("PERSIST_RUN_STATE", raising=False)
+        assert Settings().persist_run_state is False
+
+    def test_env_flag_enables(self, monkeypatch):
+        # Setting PERSIST_RUN_STATE=true flips the setting on.
+        from continuum.config import Settings
+
+        monkeypatch.setenv("PERSIST_RUN_STATE", "true")
+        assert Settings().persist_run_state is True
+
+    def test_runnerconfig_default_tracks_settings(self):
+        # Env-independent: the field must default from global settings, not a
+        # hard-coded literal.
+        from continuum.config import settings
+
+        assert RunnerConfig().persist_state == settings.persist_run_state
+
+    def test_explicit_override_wins(self):
+        # A caller passing persist_state explicitly always wins over the default.
+        assert RunnerConfig(persist_state=True).persist_state is True
+        assert RunnerConfig(persist_state=False).persist_state is False
+
+
+# ---------------------------------------------------------------------------
+# 2. Runtime behavior — does it actually skip / perform the Redis write?
+# ---------------------------------------------------------------------------
+
+
+class _FakeAgent:
+    name = "test-agent"
+
+
+class _FakeCtx:
+    run_id = "run-001"
+    session_id = "sess-abc"
+    user_id = "user-42"
+    max_turns = 5
+    trace_id = "trace-xyz"
+
+
+def _svc_with_mock_manager(persist_state: bool) -> tuple[ContextService, MagicMock]:
+    manager = MagicMock()
+    manager.save = AsyncMock()
+    svc = ContextService(
+        state_manager=manager,
+        config=RunnerConfig(persist_state=persist_state),
+    )
+    return svc, manager
+
+
+class TestPersistStateRuntime:
+    @pytest.mark.asyncio
+    async def test_off_does_not_write(self):
+        # persist_state=False: create_run_state must NOT touch the state manager.
+        svc, manager = _svc_with_mock_manager(persist_state=False)
+        await svc.create_run_state(_FakeAgent(), _FakeCtx())
+        manager.save.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_on_writes(self):
+        # persist_state=True: create_run_state must save exactly once.
+        svc, manager = _svc_with_mock_manager(persist_state=True)
+        await svc.create_run_state(_FakeAgent(), _FakeCtx())
+        manager.save.assert_awaited_once()

--- a/tests/unit/test_persist_state_default.py
+++ b/tests/unit/test_persist_state_default.py
@@ -7,11 +7,15 @@ Redis on every run, for a future pause/resume feature that is not yet implemente
 every integrator had to disable it by hand. It now defaults to the PERSIST_RUN_STATE
 env flag, which is off unless explicitly enabled.
 
-Two layers are covered:
+Three layers are covered:
   1. Config: the Settings default is off; the env flag flips it; RunnerConfig's
      default tracks settings; an explicit per-runner override still wins.
   2. Behavior: with persist_state off, ContextService never calls the state
      manager's save() (no Redis write / connection attempt); with it on, it does.
+  3. Ticket regression: with the default (disabled) config, the run path never
+     reaches for the global state manager (so no Redis connection is attempted)
+     and emits no "Failed to connect to Redis for state persistence" warning —
+     the exact symptom the ticket reported.
 """
 
 from __future__ import annotations
@@ -97,3 +101,39 @@ class TestPersistStateRuntime:
         svc, manager = _svc_with_mock_manager(persist_state=True)
         await svc.create_run_state(_FakeAgent(), _FakeCtx())
         manager.save.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# 3. Ticket regression — no Redis connection attempt / no warning by default
+# ---------------------------------------------------------------------------
+
+
+class TestTicketRegression:
+    @pytest.mark.asyncio
+    async def test_default_never_builds_state_manager(self, monkeypatch):
+        # The ticket's root cause: run-state persistence reached for Redis on the
+        # run path. With the default (disabled) config, the global state manager
+        # must never be constructed — no manager, no Redis connection attempt.
+        import continuum.agent.services.context_service as cs
+
+        def _tripwire():
+            raise AssertionError(
+                "get_global_state_manager() must not be called when persist_state is False"
+            )
+
+        monkeypatch.setattr(cs, "get_global_state_manager", _tripwire)
+
+        svc = ContextService(config=RunnerConfig())  # default -> persistence off
+        state = await svc.create_run_state(_FakeAgent(), _FakeCtx())
+        await svc.save_run_state(state)  # tripwire raises if either path touches it
+
+    @pytest.mark.asyncio
+    async def test_default_emits_no_redis_warning(self, caplog):
+        # The ticket's observable symptom: a "Failed to connect to Redis for state
+        # persistence" warning per run. With the default config it must not appear
+        # (regardless of whether Redis is reachable), since the path is never taken.
+        svc = ContextService(config=RunnerConfig())  # default -> persistence off
+        with caplog.at_level("WARNING"):
+            state = await svc.create_run_state(_FakeAgent(), _FakeCtx())
+            await svc.save_run_state(state)
+        assert not any("state persistence" in r.getMessage().lower() for r in caplog.records)


### PR DESCRIPTION
## Summary

`SESSION_ENABLED=false` only disables the session Redis. Run-state persistence is
controlled by a separate flag, `RunnerConfig.persist_state`, which defaulted to
`True` and had no environment binding — it could only be disabled in code. As a
result, every run attempted a Redis connection for state persistence, and when
Redis was unavailable it logged a warning, adding noise to the logs.

Because there was no configuration-level way to turn it off, all six playground
workflows set `persist_state=False` manually.

Run-state persistence is scaffolding for a future pause/resume/recovery feature
that is not yet implemented; nothing reads the persisted state back today. Rather
than remove it, this change makes it configurable and defaults it off, so it
remains available for the future feature without adding overhead or log noise now.

## Changes

- Add `PERSIST_RUN_STATE` setting (default `False`) in `continuum.config`.
- Bind `RunnerConfig.persist_state` to that setting; passing `persist_state`
  explicitly (`True`/`False`) still overrides per runner.
- Remove the now-redundant `persist_state=False` from the six playground workflows.
- Update `docs/agent.md` to reflect the new default and the env flag.
- Add tests covering the config default, the env flag, explicit override, and the
  runtime behavior (no state-manager write when disabled).

## Behavior change

- Default flips `True → False`. No consumer of run-state exists today, so there is
  no functional impact.
- Enable globally with `PERSIST_RUN_STATE=true`, or per runner with
  `persist_state=True`.

## Verification

- With Redis unavailable and default config: no connection attempt and no warning.
- Lint and type-check pass; six new tests pass; the existing suite is unaffected.