### PR TITLE
fix(session): Container.set_memory_client doesn't propagate to an already-initialized SessionClient (TL-82)

### DIFF
--- a/src/continuum/session/client.py
+++ b/src/continuum/session/client.py
@@ -120,6 +120,12 @@ class SessionClient:
         self._session_config = session_config or SessionConfig()
         self._provider: BaseSessionProvider | None = provider
         self._memory_client: MemoryClient | None = memory_client
+        # An explicitly supplied memory client is trusted as-is and kept for the
+        # client's lifetime. When none is supplied, the memory client is resolved
+        # LIVE from the container on each use (never cached) so that a client
+        # swapped via Container.set_memory_client() after this SessionClient was
+        # constructed takes effect — mirrors the _explicit_provider handling below.
+        self._explicit_memory_client = memory_client is not None
         self._background_tasks = background_tasks
         self._initialized = False
         self._lock = threading.Lock()
@@ -154,20 +160,32 @@ class SessionClient:
         """Get the current configuration."""
         return self._session_config
 
+    def _resolve_memory_client(self) -> MemoryClient | None:
+        """Resolve the effective memory client.
+
+        An explicitly-injected client (passed to the constructor) is honored
+        as-is. Otherwise the client is fetched LIVE from the container on every
+        call — never cached on the instance — so that Container.set_memory_client()
+        applied after this SessionClient was built takes effect immediately,
+        instead of returning a stale reference captured at init time.
+        """
+        if self._explicit_memory_client:
+            return self._memory_client
+        from continuum.core.container import get_container
+
+        return get_container().memory_client
+
     @property
     def memory_client(self) -> MemoryClient:
-        """Get the memory client from Container."""
-        if not self._memory_client:
-            from continuum.core.container import get_container
-
-            client = get_container().memory_client
-            if client is None:
-                raise RuntimeError(
-                    "MemoryClient is not available. Ensure memory is enabled "
-                    "and properly configured (MEMORY_ENABLED=true)."
-                )
-            self._memory_client = client
-        return self._memory_client
+        """Get the effective memory client, resolving from the container when one
+        was not explicitly injected."""
+        client = self._resolve_memory_client()
+        if client is None:
+            raise RuntimeError(
+                "MemoryClient is not available. Ensure memory is enabled "
+                "and properly configured (MEMORY_ENABLED=true)."
+            )
+        return client
 
     @property
     def background_tasks(self) -> BackgroundTaskRegistry | None:
@@ -394,11 +412,12 @@ class SessionClient:
             # constructing the client never opens a connection, and a disabled
             # or unreachable Redis costs no eager connection attempt.
 
-            # Initialize memory client from Container (if not provided)
-            if not self._memory_client:
-                from continuum.core.container import get_container
-
-                self._memory_client = get_container().memory_client
+            # NOTE: the memory client is intentionally NOT resolved here either.
+            # It is fetched lazily from the container on each use (see
+            # _resolve_memory_client) so that a memory client swapped on the
+            # container AFTER this SessionClient is constructed is picked up,
+            # rather than a stale reference cached at init time. An explicitly
+            # injected memory client is always honored as-is.
 
             self._initialized = True
             return True
@@ -508,7 +527,8 @@ class SessionClient:
             # In 'background' mode the (potentially slow) mem0 fact-extraction is
             # scheduled as a fire-and-forget task so it does not add latency to the
             # response; the short-term Redis write above is always synchronous.
-            if store_in_memory and self._memory_client and self._memory_client.is_enabled:
+            memory_client = self._resolve_memory_client()
+            if store_in_memory and memory_client and memory_client.is_enabled:
                 registry = self.background_tasks
                 # Resolve the EFFECTIVE write mode at call time. Inside a Temporal
                 # activity we always force 'sync' so the mem0 write completes within
@@ -800,7 +820,8 @@ class SessionClient:
         """
         self._ensure_enabled()
 
-        if not self._memory_client or not self._memory_client.is_enabled:
+        memory_client = self._resolve_memory_client()
+        if not memory_client or not memory_client.is_enabled:
             logger.warning("Memory client not enabled, returning empty list")
             return []
 

--- a/tests/integration/test_memory_background_write.py
+++ b/tests/integration/test_memory_background_write.py
@@ -1,9 +1,14 @@
-"""Integration: background memory writes wired through the DI container.
+"""Integration: memory-client wiring through the DI container.
 
-Verifies the two container-level contracts that the unit tests can't cover:
-  1. The container injects its shared BackgroundTaskRegistry into the SessionClient.
-  2. container.shutdown() drains in-flight background memory writes (so a write
-     scheduled in 'background' mode is not lost at shutdown).
+Covers the container-level contracts the unit tests can't:
+  1. A background memory write scheduled through the container-built SessionClient
+     lands on the container's shared BackgroundTaskRegistry.
+  2. container.shutdown() drains in-flight background memory writes BEFORE closing
+     the memory client (so a write scheduled in 'background' mode is not lost),
+     and stays clean even when a pending write errors.
+  3. A container-derived memory client is resolved LIVE on every use, so
+     Container.set_memory_client() applied after a SessionClient exists takes
+     effect (TL-82 fix); an explicitly injected client is trusted for life.
 
 Uses mocked provider + memory client — no Redis, no mem0/LLM, no vector store.
 """
@@ -12,11 +17,16 @@ from __future__ import annotations
 
 import asyncio
 from datetime import UTC, datetime
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from continuum.core.container import Container, ContainerConfig
+from continuum.core.container import (
+    Container,
+    ContainerConfig,
+    get_container,
+    reset_container,
+)
 from continuum.llm.types import ChatMessage
 from continuum.session.client import SessionClient
 from continuum.session.config import SessionConfig
@@ -41,6 +51,7 @@ def _mock_memory_client(add_mock=None):
     mem = MagicMock()
     mem.is_enabled = True
     mem.add = add_mock or AsyncMock(return_value=MagicMock(results=[]))
+    mem.search = AsyncMock(return_value=MagicMock(results=[]))
     mem.delete = AsyncMock()
     mem.close = AsyncMock()
     return mem
@@ -60,34 +71,55 @@ def _msg():
 
 class TestContainerWiring:
     async def test_container_injects_registry_into_session_client(self):
-        container = Container(
-            ContainerConfig(session_config={"enabled": True, "provider": "redis"})
+        # Behavioral (not a private-attribute check): a memory write scheduled in
+        # background mode through the container-built session client must land on
+        # the container's own shared BackgroundTaskRegistry.
+        reset_container()
+        container = get_container(
+            ContainerConfig(
+                enable_memory=True,
+                enable_session=True,
+                session_config={"enabled": True, "memory_write_mode": "background"},
+            )
         )
+        container.set_memory_client(_mock_memory_client())
         try:
-            with patch(
-                "continuum.session.providers.create_provider",
-                return_value=_mock_provider(),
-            ):
-                session_client = container.session_client
-
+            session_client = container.session_client
             assert session_client is not None
-            # The session client shares the container's single registry instance.
-            assert session_client._background_tasks is container.background_tasks
+            # Inject a mock provider onto the container-built singleton (public
+            # API) so ops run without Redis.
+            session_client.set_provider(_mock_provider())
+
+            await session_client.add_message("sess-1234abcd", _msg())
+
+            # The background mem0 write was scheduled on the container's registry.
+            assert len(container.background_tasks) == 1
+            await container.background_tasks.drain(timeout=5.0)
+            assert len(container.background_tasks) == 0
         finally:
-            container.reset()
+            reset_container()
 
 
 class TestShutdownDrain:
     async def test_pending_background_write_completes_on_shutdown(self):
-        completed = {"done": False}
+        # Ordering + no-hang: an in-flight background write must be drained to
+        # completion BEFORE the memory client is closed. The gate is released
+        # shortly after shutdown starts, and shutdown is bounded so a drain
+        # regression fails loudly instead of hanging CI.
+        events: list[str] = []
+        gate = asyncio.Event()
 
-        async def _slow_add(*args, **kwargs):
-            await asyncio.sleep(0.2)
-            completed["done"] = True
+        async def _gated_add(*args, **kwargs):
+            await gate.wait()
+            events.append("add_done")
             return MagicMock(results=[])
 
+        async def _close():
+            events.append("close")
+
         container = Container(ContainerConfig())
-        mem = _mock_memory_client(add_mock=AsyncMock(side_effect=_slow_add))
+        mem = _mock_memory_client(add_mock=AsyncMock(side_effect=_gated_add))
+        mem.close = AsyncMock(side_effect=_close)
         container.set_memory_client(mem)
 
         # Build a session client on the container's shared registry (background mode).
@@ -103,16 +135,58 @@ class TestShutdownDrain:
         try:
             await session_client.add_message("sess-1234abcd", _msg())
 
-            # Returned before the slow write finished — it's in flight on the registry.
+            # Returned before the gated write ran — it's in flight on the registry.
             assert mem.add.await_count == 0
             assert len(container.background_tasks) == 1
-            assert completed["done"] is False
 
-            # Shutdown must drain the in-flight write before closing the memory client.
-            await container.shutdown()
+            loop = asyncio.get_running_loop()
+            loop.call_later(0.05, gate.set)  # release shortly after shutdown starts
 
-            assert completed["done"] is True
+            # Shutdown must drain the in-flight write before closing the client.
+            await asyncio.wait_for(container.shutdown(), timeout=5)
+
+            # The write finished, and it finished BEFORE the client was closed.
+            assert events == ["add_done", "close"]
             assert mem.add.await_count == 1
+            assert mem.close.await_count == 1
+            assert len(container.background_tasks) == 0
+        finally:
+            container.reset()
+
+    async def test_shutdown_stays_clean_when_background_write_raises(self):
+        # A pending background write that raises must not break shutdown: drain
+        # swallows/observes the failure, and the memory client is still closed
+        # exactly once.
+        gate = asyncio.Event()
+
+        async def _boom(*args, **kwargs):
+            await gate.wait()
+            raise RuntimeError("mem0 add failed")
+
+        container = Container(ContainerConfig())
+        mem = _mock_memory_client(add_mock=AsyncMock(side_effect=_boom))
+        container.set_memory_client(mem)
+
+        session_client = SessionClient(
+            session_config=SessionConfig(enabled=True, memory_write_mode="background"),
+            memory_client=mem,
+            provider=_mock_provider(),
+            auto_initialize=False,
+            background_tasks=container.background_tasks,
+        )
+        container.set_session_client(session_client)
+
+        try:
+            await session_client.add_message("sess-1234abcd", _msg())
+            assert len(container.background_tasks) == 1
+
+            loop = asyncio.get_running_loop()
+            loop.call_later(0.05, gate.set)  # let the in-flight write reach its raise
+
+            # Must complete without propagating the background write's error.
+            await asyncio.wait_for(container.shutdown(), timeout=5)
+
+            assert mem.close.await_count == 1
             assert len(container.background_tasks) == 0
         finally:
             container.reset()
@@ -126,3 +200,248 @@ class TestShutdownDrain:
             assert len(container.background_tasks) == 0
         finally:
             container.reset()
+
+
+class TestMemoryClientLiveResolution:
+    """Regression guard: a SessionClient that resolved its memory client from
+    the container must NOT cache it at construction time.
+
+    The bug this guards against: Container.set_memory_client() applied AFTER a
+    SessionClient was already built silently had no effect — the SessionClient
+    kept using the stale memory client captured when it was first initialized,
+    so session memory reads/writes hit the OLD backend with no error or warning.
+
+    These tests assert on observable behavior (which mock's add()/search() is
+    actually invoked), not on private attributes, so the contract survives
+    internal refactors and can't be quietly weakened.
+
+    SessionClient resolves the container-derived memory client through the
+    GLOBAL get_container(), so the autouse fixture resets the global container
+    around each test.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _reset_global_container(self):
+        reset_container()
+        yield
+        reset_container()
+
+    async def test_bug_report_repro_through_container_singleton(self):
+        """The exact bug-report sequence, through the cached
+        container.session_client singleton — no manually constructed
+        SessionClient. Fails against the pre-fix caching impl: the singleton
+        would keep using the memory client captured when it was first built."""
+        container = get_container(
+            ContainerConfig(
+                enable_memory=True,
+                enable_session=True,
+                session_config={"enabled": True, "memory_write_mode": "sync"},
+            )
+        )
+        old_mem = _mock_memory_client()
+        container.set_memory_client(old_mem)
+
+        # The cached singleton. Inject a mock provider (public API) so ops run
+        # without Redis; the memory client is left to resolve from the container.
+        session_client = container.session_client
+        session_client.set_provider(_mock_provider())
+
+        await session_client.add_message("sess-1234abcd", _msg())
+        assert old_mem.add.await_count == 1
+
+        # Swap the container's memory client after the singleton was built + used.
+        new_mem = _mock_memory_client()
+        container.set_memory_client(new_mem)
+
+        # Same singleton instance now reflects the swapped client...
+        assert container.session_client.memory_client is new_mem
+        # ...and routes subsequent writes to it, not the stale one.
+        await container.session_client.add_message("sess-1234abcd", _msg())
+        assert new_mem.add.await_count == 1
+        assert old_mem.add.await_count == 1  # unchanged — no longer used
+
+    async def test_swap_after_build_routes_writes_to_new_client(self):
+        """Fails against the pre-fix impl: after the swap the write would still
+        go to the memory client cached at construction time."""
+        container = get_container(ContainerConfig(enable_memory=True))
+        old_mem = _mock_memory_client()
+        container.set_memory_client(old_mem)
+
+        # Built WITHOUT an explicit memory client → resolves from the container
+        # (the default/common path). Sync write mode keeps the mem0 write inline
+        # so the assertion doesn't race a background task.
+        session_client = SessionClient(
+            session_config=SessionConfig(enabled=True, memory_write_mode="sync"),
+            provider=_mock_provider(),
+            auto_initialize=True,
+        )
+        # First write goes to the client the container had at build time.
+        await session_client.add_message("sess-1234abcd", _msg())
+        assert old_mem.add.await_count == 1
+
+        # Swap the container's memory client AFTER the session client was
+        # built and already used.
+        new_mem = _mock_memory_client()
+        container.set_memory_client(new_mem)
+
+        # The next write must route to the NEW client — proving the session
+        # client re-resolves live instead of using the stale reference.
+        await session_client.add_message("sess-1234abcd", _msg())
+        assert new_mem.add.await_count == 1
+        assert old_mem.add.await_count == 1  # unchanged — no longer used
+
+    async def test_explicit_memory_client_is_not_overridden_by_container(self):
+        # The other half of the contract: an explicitly injected memory client
+        # is trusted for the client's lifetime and is NEVER swapped out by the
+        # container — this is the pre-existing behavior and must not regress.
+        # (Passes both pre- and post-fix; guards against over-correcting.)
+        container = get_container(ContainerConfig(enable_memory=True))
+        container.set_memory_client(_mock_memory_client())
+
+        explicit_mem = _mock_memory_client()
+        session_client = SessionClient(
+            session_config=SessionConfig(enabled=True, memory_write_mode="sync"),
+            memory_client=explicit_mem,
+            provider=_mock_provider(),
+            auto_initialize=True,
+        )
+        await session_client.add_message("sess-1234abcd", _msg())
+        # Writes go to the explicitly injected client, never the container's.
+        assert explicit_mem.add.await_count == 1
+
+        # Even after a container swap, the explicit client is still honored.
+        container.set_memory_client(_mock_memory_client())
+        await session_client.add_message("sess-1234abcd", _msg())
+        assert explicit_mem.add.await_count == 2
+
+    async def test_swap_reflected_in_read_path(self):
+        """Fails against the pre-fix impl: the read path would keep searching the
+        memory client cached at construction time."""
+        container = get_container(ContainerConfig(enable_memory=True))
+        old_mem = _mock_memory_client()
+        container.set_memory_client(old_mem)
+
+        session_client = SessionClient(
+            session_config=SessionConfig(enabled=True),
+            provider=_mock_provider(),
+            auto_initialize=True,
+        )
+        await session_client.get_relevant_memories("sess-1234abcd", query="who am i")
+        assert old_mem.search.await_count == 1
+
+        new_mem = _mock_memory_client()
+        container.set_memory_client(new_mem)
+
+        await session_client.get_relevant_memories("sess-1234abcd", query="who am i")
+        assert new_mem.search.await_count == 1
+        assert old_mem.search.await_count == 1  # unchanged
+
+    async def test_swap_reflected_in_background_write_mode(self):
+        """Fails against the pre-fix impl: in background mode too, the write
+        would resolve the stale cached client."""
+        container = get_container(ContainerConfig(enable_memory=True))
+        old_mem = _mock_memory_client()
+        container.set_memory_client(old_mem)
+
+        session_client = SessionClient(
+            session_config=SessionConfig(enabled=True, memory_write_mode="background"),
+            provider=_mock_provider(),
+            auto_initialize=True,
+            background_tasks=container.background_tasks,
+        )
+        await session_client.add_message("sess-1234abcd", _msg())
+        await container.background_tasks.drain(timeout=5.0)
+        assert old_mem.add.await_count == 1
+
+        new_mem = _mock_memory_client()
+        container.set_memory_client(new_mem)
+
+        await session_client.add_message("sess-1234abcd", _msg())
+        await container.background_tasks.drain(timeout=5.0)
+        assert new_mem.add.await_count == 1
+        assert old_mem.add.await_count == 1  # unchanged
+
+    async def test_write_path_skips_disabled_memory_client(self):
+        # Guard coverage: a memory client with is_enabled=False must be skipped
+        # on the write path — no add(), no raise — while the short-term session
+        # write (provider.add_message) still succeeds.
+        container = get_container(ContainerConfig(enable_memory=True))
+        disabled = _mock_memory_client()
+        disabled.is_enabled = False
+        container.set_memory_client(disabled)
+
+        provider = _mock_provider()
+        session_client = SessionClient(
+            session_config=SessionConfig(enabled=True, memory_write_mode="sync"),
+            provider=provider,
+            auto_initialize=True,
+        )
+        # Must not raise.
+        await session_client.add_message("sess-1234abcd", _msg())
+
+        assert disabled.add.await_count == 0  # memory skipped
+        assert provider.add_message.await_count == 1  # session write still happened
+
+    async def test_read_path_returns_empty_with_disabled_memory_client(self):
+        # Guard coverage on the read path: a disabled memory client makes
+        # get_relevant_memories return an empty list without calling search()
+        # (asserting the actual implementation behavior at client.py:823-825).
+        container = get_container(ContainerConfig(enable_memory=True))
+        disabled = _mock_memory_client()
+        disabled.is_enabled = False
+        container.set_memory_client(disabled)
+
+        session_client = SessionClient(
+            session_config=SessionConfig(enabled=True),
+            provider=_mock_provider(),
+            auto_initialize=True,
+        )
+        result = await session_client.get_relevant_memories("sess-1234abcd", query="q")
+
+        assert result == []
+        assert disabled.search.await_count == 0
+
+    async def test_swap_to_none_disables_memory_writes_gracefully(self):
+        """Fails against the pre-fix impl: the stale cached client would keep
+        receiving writes after the container was set to None."""
+        container = get_container(ContainerConfig(enable_memory=True))
+        old_mem = _mock_memory_client()
+        container.set_memory_client(old_mem)
+
+        session_client = SessionClient(
+            session_config=SessionConfig(enabled=True, memory_write_mode="sync"),
+            provider=_mock_provider(),
+            auto_initialize=True,
+        )
+        await session_client.add_message("sess-1234abcd", _msg())
+        assert old_mem.add.await_count == 1
+
+        container.set_memory_client(None)
+
+        # Must not raise; the memory write is simply skipped.
+        await session_client.add_message("sess-1234abcd", _msg())
+        assert old_mem.add.await_count == 1  # unchanged — no client to write to
+
+    async def test_property_resolves_live_each_access(self):
+        """Fails against the pre-fix impl: the property would return the first
+        resolved client forever. Direct property-level check complementing the
+        behavioral tests."""
+        container = get_container(ContainerConfig(enable_memory=True))
+
+        session_client = SessionClient(
+            session_config=SessionConfig(enabled=True),
+            provider=_mock_provider(),
+            auto_initialize=True,
+        )
+        old_mem = _mock_memory_client()
+        container.set_memory_client(old_mem)
+        assert session_client.memory_client is old_mem
+
+        new_mem = _mock_memory_client()
+        container.set_memory_client(new_mem)
+        assert session_client.memory_client is new_mem
+
+        # No client available → the property raises a clear error.
+        container.set_memory_client(None)
+        with pytest.raises(RuntimeError, match="MemoryClient is not available"):
+            _ = session_client.memory_client


### PR DESCRIPTION
## Problem
`Container.set_memory_client(...)` applied **after** a `SessionClient` was already
built had no effect — the session client kept using the memory client it captured
at construction time. Because `Container.session_client` is a cached singleton,
any flow that touches the session client once and then reconfigures the memory
client (tests injecting a mock, an app swapping backends at runtime) silently kept
reading/writing session memory against the **old (or already-closed) client**, with
no error or warning.

## Root cause
`SessionClient` resolved the container's memory client on first use and cached it on
the instance, re-reading the container only while the cached reference was still
`None`:
- `initialize()` eagerly resolved and cached `get_container().memory_client`.
- the `memory_client` property only refreshed `if not self._memory_client`.

Once populated, it was never refreshed, so a later `set_memory_client()` could not
reach it.

## Fix
Resolve a container-derived memory client **live on every use**, never caching it —
while still trusting an **explicitly injected** client for the client's lifetime.
This mirrors the existing `_explicit_provider` pattern already used for the session
provider.

- New `_resolve_memory_client()`: explicit → return the injected client; otherwise →
  fetch live from the container each call.
- `memory_client` property delegates to the resolver (same "not available" error).
- `initialize()` no longer eagerly resolves/caches the memory client.
- The write guard (`add_message`) and read guard (`get_relevant_memories`) use the
  resolver instead of the raw cached attribute.

Behavior is unchanged for explicitly-injected clients; only the container-derived
(default) path now reflects later swaps.

## Tests
`tests/integration/test_memory_background_write.py` → `TestMemoryClientLiveResolution`
(mocks only — no Redis, mem0, LLM, or network):
- exact bug-report repro through the cached `container.session_client` singleton
- write path, read path, and background write mode all re-resolve after a swap
- `set_memory_client(None)` skips memory writes gracefully (no crash)
- `is_enabled=False` guard coverage on both write and read paths
- explicitly-injected client is never overridden by the container
- plus behavioral container-wiring and shutdown-drain/ordering coverage

Every swap test **fails against the pre-fix code and passes with the fix**.

## Verification
- Full unit suite unchanged from baseline — no new failures.
- `ruff` clean; `mypy` adds no new errors on the changed module.

