### PR TITLE
feat(executor): attribute token usage per resolved model in TokenUsage.model_usage

### DIFF
--- a/src/continuum/agent/execution/executor.py
+++ b/src/continuum/agent/execution/executor.py
@@ -72,6 +72,38 @@ def _enrich_config_for_gateway(config: LLMConfig, context: RunContext) -> LLMCon
     )
 
 
+def _usage_with_model(response: Any, fallback_model: str | None) -> TokenUsage:
+    """Build a single-call ``TokenUsage`` attributed to the RESOLVED model.
+
+    ``model_usage`` is keyed on ``response.model`` — the id the provider/gateway
+    actually served. Under the Smart Gateway the agent's configured model is the
+    literal placeholder ``"auto"``, so ``response.model`` is the only billable
+    identity for the call. Falls back to the agent's configured model when the
+    provider omits ``model``; when neither is known the per-model entry is
+    skipped (top-level totals still accumulate).
+    """
+    prompt = int(response.usage.prompt_tokens or 0)
+    completion = int(response.usage.completion_tokens or 0)
+    total = int(response.usage.total_tokens or 0)
+    model = getattr(response, "model", None) or fallback_model
+    return TokenUsage(
+        prompt_tokens=prompt,
+        completion_tokens=completion,
+        total_tokens=total,
+        model_usage=(
+            {
+                model: {
+                    "prompt_tokens": prompt,
+                    "completion_tokens": completion,
+                    "total_tokens": total,
+                }
+            }
+            if model
+            else {}
+        ),
+    )
+
+
 class Executor(IExecutor):
     """
     Core executor for agent runs.
@@ -315,15 +347,11 @@ class Executor(IExecutor):
                     turn_span.set_error(str(e))
                     raise
 
-                # Track usage
+                # Track usage — attributed to the RESOLVED model (response.model),
+                # not the configured one, so per-model metering works under the
+                # Smart Gateway where the configured model is just "auto".
                 if response.usage:
-                    total_usage = total_usage.add(
-                        TokenUsage(
-                            prompt_tokens=response.usage.prompt_tokens or 0,
-                            completion_tokens=response.usage.completion_tokens or 0,
-                            total_tokens=response.usage.total_tokens or 0,
-                        )
-                    )
+                    total_usage = total_usage.add(_usage_with_model(response, agent.model))
                     turn_span.add_metadata(
                         "tokens",
                         {
@@ -654,6 +682,11 @@ class Executor(IExecutor):
                                         f"🔁 RETURN TO PARENT [{agent.name}] ← [{target}]\n"
                                         f"[tool] {executor_content[:500]}\n" + "=" * 30
                                     )
+                                    # Child-run usage is a full TokenUsage whose
+                                    # model_usage the child's own executor loop
+                                    # populated; add() merges the per-model map.
+                                    # No response.model exists here — this is an
+                                    # aggregated multi-turn response, not one call.
                                     total_usage = total_usage.add(handoff_result.response.usage)
                                     # Pop the target agent so the parent can hand off
                                     # to the same target again on the next turn.
@@ -699,6 +732,8 @@ class Executor(IExecutor):
                                         content=handoff_result.response.content,
                                         agent_name=handoff_result.response.agent_name,
                                         status=ResponseStatus.SUCCESS,
+                                        # add() merges the child's per-model map
+                                        # (see return_to_parent comment above).
                                         usage=total_usage.add(handoff_result.response.usage),
                                         turn_count=turn,
                                         handoff_result=handoff_result,
@@ -869,11 +904,9 @@ class Executor(IExecutor):
 
         usage = TokenUsage()
         if response.usage:
-            usage = TokenUsage(
-                prompt_tokens=response.usage.prompt_tokens or 0,
-                completion_tokens=response.usage.completion_tokens or 0,
-                total_tokens=response.usage.total_tokens or 0,
-            )
+            # Attribute to the resolved model (see _usage_with_model) so the
+            # reasoning pass is metered per-model like the main turn loop.
+            usage = _usage_with_model(response, agent.model)
 
         return response.content or "", usage
 
@@ -921,13 +954,8 @@ class Executor(IExecutor):
             )
 
             if response.usage:
-                total_usage = total_usage.add(
-                    TokenUsage(
-                        prompt_tokens=response.usage.prompt_tokens or 0,
-                        completion_tokens=response.usage.completion_tokens or 0,
-                        total_tokens=response.usage.total_tokens or 0,
-                    )
-                )
+                # Same per-resolved-model attribution as the main turn loop.
+                total_usage = total_usage.add(_usage_with_model(response, agent.model))
 
             content = response.content or ""
             action, action_input, final_answer = self._parse_react_action(content)

--- a/src/continuum/agent/runner.py
+++ b/src/continuum/agent/runner.py
@@ -1392,6 +1392,9 @@ class AgentRunner:
                         trace_id=ctx.trace_id,
                     )
 
+                # NOTE: no usage= is passed — streamed runs carry an EMPTY
+                # TokenUsage (zero totals, no model_usage). Callers must NOT
+                # rely on streamed responses for billing/metering.
                 response = AgentResponse(
                     content=content,
                     run_id=ctx.run_id,
@@ -1931,6 +1934,9 @@ class AgentRunner:
                         f"{structured_output_error}"
                     )
 
+            # NOTE: no usage= is passed — streamed runs carry an EMPTY TokenUsage
+            # (zero totals, no model_usage). Callers must NOT rely on streamed
+            # responses for billing/metering.
             response = AgentResponse(
                 content=content,
                 structured_output=structured_output,

--- a/tests/unit/agent/test_executor_model_usage.py
+++ b/tests/unit/agent/test_executor_model_usage.py
@@ -1,0 +1,313 @@
+"""
+Tests for per-resolved-model usage attribution (TokenUsage.model_usage).
+
+The executor must key each LLM call's tokens on ``response.model`` — the id the
+provider/gateway actually served — because under the Smart Gateway the agent's
+configured model is the literal placeholder "auto". Downstream metering
+(audiex MeteringRunner) prices per model_usage entry and falls back to the
+configured model only when model_usage is empty, which yields zero-cost ledger
+rows for "auto". These tests drive the REAL Executor with fake LLM responses.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+from continuum.agent.base import BaseAgent
+from continuum.agent.config import AgentConfig
+from continuum.agent.execution.executor import Executor
+from continuum.agent.types import (
+    AgentResponse,
+    Handoff,
+    HandoffResult,
+    ResponseStatus,
+    RunContext,
+    RunState,
+    TokenUsage,
+)
+
+
+def _usage(prompt, completion):
+    return SimpleNamespace(
+        prompt_tokens=prompt,
+        completion_tokens=completion,
+        total_tokens=prompt + completion,
+    )
+
+
+class _FakeFn:
+    def __init__(self, name, arguments):
+        self.name = name
+        self.arguments = arguments
+
+
+class _FakeToolCall:
+    def __init__(self, id, name, arguments):
+        self.id = id
+        self.function = _FakeFn(name, arguments)
+
+    def to_dict(self):
+        return {
+            "id": self.id,
+            "function": {"name": self.function.name, "arguments": self.function.arguments},
+        }
+
+
+def _final_response(model, prompt, completion, content="done"):
+    return SimpleNamespace(
+        content=content,
+        tool_calls=None,
+        usage=_usage(prompt, completion),
+        model=model,
+    )
+
+
+def _think_response(model, prompt, completion):
+    # A "think" tool call is handled inline by the executor (no ToolHandler
+    # needed) and keeps the loop going — the cleanest way to force a 2nd turn.
+    return SimpleNamespace(
+        content="",
+        tool_calls=[_FakeToolCall("tc-think", "think", '{"thought": "hmm"}')],
+        usage=_usage(prompt, completion),
+        model=model,
+    )
+
+
+def _agent(**kwargs):
+    kwargs.setdefault("name", "meter-agent")
+    kwargs.setdefault("instructions", "answer")
+    kwargs.setdefault("config", AgentConfig())
+    kwargs.setdefault("model", "configured-model")
+    return BaseAgent(**kwargs)
+
+
+def _ctx(max_turns=6):
+    return RunContext(run_id="run-meter", max_turns=max_turns)
+
+
+def _run_state():
+    rs = RunState(run_id="run-meter")
+    rs.push_agent("meter-agent")
+    return rs
+
+
+class TestPerModelAttribution:
+    async def test_two_turn_run_attributes_per_resolved_model(self):
+        # Turn 1 resolves to one model, turn 2 to another (gateway tier routing
+        # can do exactly this) → two model_usage entries with the right sums.
+        llm = SimpleNamespace(
+            chat=AsyncMock(
+                side_effect=[
+                    _think_response("openai/gpt-4o-mini", 10, 5),
+                    _final_response("anthropic/claude-sonnet-4-5", 20, 7),
+                ]
+            )
+        )
+        ex = Executor(llm_client=llm)
+
+        response = await ex.execute_loop(
+            _agent(), [{"role": "user", "content": "q"}], _ctx(), _run_state()
+        )
+
+        assert response.usage.model_usage == {
+            "openai/gpt-4o-mini": {
+                "prompt_tokens": 10,
+                "completion_tokens": 5,
+                "total_tokens": 15,
+            },
+            "anthropic/claude-sonnet-4-5": {
+                "prompt_tokens": 20,
+                "completion_tokens": 7,
+                "total_tokens": 27,
+            },
+        }
+        # Top-level totals still equal the sum of the per-model breakdown.
+        assert response.usage.prompt_tokens == 30
+        assert response.usage.completion_tokens == 12
+        assert response.usage.total_tokens == 42
+
+    async def test_same_resolved_model_sums_into_one_entry(self):
+        llm = SimpleNamespace(
+            chat=AsyncMock(
+                side_effect=[
+                    _think_response("openai/gpt-4o", 10, 5),
+                    _final_response("openai/gpt-4o", 20, 7),
+                ]
+            )
+        )
+        ex = Executor(llm_client=llm)
+
+        response = await ex.execute_loop(
+            _agent(), [{"role": "user", "content": "q"}], _ctx(), _run_state()
+        )
+
+        assert response.usage.model_usage == {
+            "openai/gpt-4o": {
+                "prompt_tokens": 30,
+                "completion_tokens": 12,
+                "total_tokens": 42,
+            }
+        }
+        assert response.usage.total_tokens == 42
+
+    async def test_missing_response_model_falls_back_to_configured_model(self):
+        # Provider omitted `model` → attribute to the agent's configured model
+        # rather than dropping the tokens from the per-model map.
+        llm = SimpleNamespace(chat=AsyncMock(return_value=_final_response("", 8, 4)))
+        ex = Executor(llm_client=llm)
+
+        response = await ex.execute_loop(
+            _agent(model="configured-model"),
+            [{"role": "user", "content": "q"}],
+            _ctx(),
+            _run_state(),
+        )
+
+        assert response.usage.model_usage == {
+            "configured-model": {
+                "prompt_tokens": 8,
+                "completion_tokens": 4,
+                "total_tokens": 12,
+            }
+        }
+
+    async def test_reasoning_pass_usage_is_attributed(self):
+        # reasoning_mode adds a silent think-first call before the turn loop;
+        # its tokens must land in model_usage too (keyed on ITS resolved model).
+        llm = SimpleNamespace(
+            chat=AsyncMock(
+                side_effect=[
+                    _final_response("openai/gpt-4o-mini", 3, 2, content="thinking..."),
+                    _final_response("anthropic/claude-sonnet-4-5", 10, 5),
+                ]
+            )
+        )
+        ex = Executor(llm_client=llm)
+
+        response = await ex.execute_loop(
+            _agent(config=AgentConfig(reasoning_mode=True)),
+            [{"role": "user", "content": "q"}],
+            _ctx(),
+            _run_state(),
+        )
+
+        assert response.usage.model_usage == {
+            "openai/gpt-4o-mini": {
+                "prompt_tokens": 3,
+                "completion_tokens": 2,
+                "total_tokens": 5,
+            },
+            "anthropic/claude-sonnet-4-5": {
+                "prompt_tokens": 10,
+                "completion_tokens": 5,
+                "total_tokens": 15,
+            },
+        }
+        assert response.usage.total_tokens == 20
+
+    async def test_react_loop_attributes_resolved_model(self):
+        llm = SimpleNamespace(
+            chat=AsyncMock(
+                return_value=_final_response(
+                    "openai/gpt-4o-mini", 4, 2, content="Action: Final Answer\nFinal Answer: ok"
+                )
+            )
+        )
+        ex = Executor(llm_client=llm)
+
+        response = await ex._execute_react_loop(
+            _agent(), [{"role": "user", "content": "q"}], _ctx(), _run_state()
+        )
+
+        assert response.content == "ok"
+        assert response.usage.model_usage == {
+            "openai/gpt-4o-mini": {
+                "prompt_tokens": 4,
+                "completion_tokens": 2,
+                "total_tokens": 6,
+            }
+        }
+
+
+class _StubHandoff:
+    """Mimics HandoffExecutor: pushes target, records the hop, returns a child
+    response whose usage carries its OWN per-model breakdown (as a real child
+    executor loop now produces)."""
+
+    def __init__(self, child_usage: TokenUsage):
+        self._executor = None
+        self._child_usage = child_usage
+
+    async def execute_handoff(self, agent, target_name, tool_call, messages, context, run_state):
+        run_state.push_agent(target_name)
+        run_state.handoff_chain.append({"to_agent": target_name})
+        return HandoffResult(
+            handoff_id="h",
+            from_agent=agent.name,
+            to_agent=target_name,
+            success=True,
+            response=AgentResponse(
+                content="specialist answer",
+                agent_name=target_name,
+                status=ResponseStatus.SUCCESS,
+                usage=self._child_usage,
+            ),
+        )
+
+
+class TestHandoffMerge:
+    async def test_child_model_usage_merges_into_parent_totals(self):
+        # return_to_parent handoff: the child's per-model map must merge into
+        # the parent run's usage via TokenUsage.add() — no direct response.model
+        # exists at the handoff accumulation site (aggregated multi-turn usage).
+        child_usage = TokenUsage(
+            prompt_tokens=5,
+            completion_tokens=5,
+            total_tokens=10,
+            model_usage={
+                "google/gemini-2.5-flash": {
+                    "prompt_tokens": 5,
+                    "completion_tokens": 5,
+                    "total_tokens": 10,
+                }
+            },
+        )
+        handoff_call = SimpleNamespace(
+            content="",
+            tool_calls=[_FakeToolCall("tc-h", "handoff_to_billing", "{}")],
+            usage=_usage(10, 5),
+            model="openai/gpt-4o",
+        )
+        llm = SimpleNamespace(
+            chat=AsyncMock(
+                side_effect=[handoff_call, _final_response("openai/gpt-4o", 20, 10)]
+            )
+        )
+        agent = _agent(
+            name="triage",
+            handoffs=[Handoff(target_agent="billing", description="billing q")],
+        )
+        ex = Executor(llm_client=llm, handoff_executor=_StubHandoff(child_usage))
+        rs = RunState(run_id="run-meter")
+        rs.push_agent("triage")
+
+        response = await ex.execute_loop(
+            agent, [{"role": "user", "content": "refund"}], _ctx(), rs
+        )
+
+        assert response.usage.model_usage == {
+            "openai/gpt-4o": {
+                "prompt_tokens": 30,
+                "completion_tokens": 15,
+                "total_tokens": 45,
+            },
+            "google/gemini-2.5-flash": {
+                "prompt_tokens": 5,
+                "completion_tokens": 5,
+                "total_tokens": 10,
+            },
+        }
+        assert response.usage.prompt_tokens == 35
+        assert response.usage.completion_tokens == 20
+        assert response.usage.total_tokens == 55


### PR DESCRIPTION
model_usage was declared but never populated — the executor accumulated per-turn tokens into total_usage and discarded response.model (the gateway's resolved id it already logs at 'Gateway selected model'). Downstream meters (audiex MeteringRunner) therefore attribute all tokens to the agent's configured model — the literal string "auto" under the smart gateway — producing zero-cost ledger rows.

- _usage_with_model helper; turn loop, reasoning pass, and ReAct loop accumulate model_usage keyed on response.model, falling back to the agent's configured model; totals unchanged
- handoff merge sites untouched: the child run's own loop populates its map and TokenUsage.add() already merges it
- run_stream: comments at both AgentResponse construction sites — streamed runs carry empty usage and must not be used for billing
- 6 unit tests (two-model attribution, fallback, same-model summing, reasoning/ReAct attribution, handoff merge)

Full unit suite: 1293 passed. Consumer verified against audiex's MeteringRunner shape (dict[str, dict[str,int]] with prompt/completion/total per model) — no consumer change needed.