### PR TITLE
chore(ci): add unified security scan workflow to dev

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -1,0 +1,19 @@
+name: Security Scan
+
+on:
+  pull_request:
+    branches: ['*']
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  trufflehog-scan:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Run TruffleHog Composite Action
+        uses: shyftlabs/global-devops-runner-template/.github/actions/trufflehog@main
+        with:
+          base: ${{ github.event.pull_request.base.sha }}
+          head: ${{ github.event.pull_request.head.sha }}


### PR DESCRIPTION
## Summary

Brings the org-wide TruffleHog secret-scanning workflow onto `dev`.

`infra-shyftlabs` pushed `d1d1e0c` **directly to `main`** on 2026-08-05 as part of a rollout across the org — all 12 `shyftlabs` repos sampled carry this file, each on its default branch. Continuum's default branch is `main`, so that is where it landed here.

This is a cherry-pick of that exact commit, so the original authorship and message are preserved. The file is byte-identical to `main`'s copy; nothing else changes.

## Why `dev` needs it

The workflow triggers on `pull_request`, but **GitHub reads workflow definitions from the base branch**. Every PR in this repo targets `dev`, which does not have the file — so TruffleHog has never run on any PR here, including #85 and #87.

That is a live gap: `dff8244` on this branch replaced a Redis password that had been committed to the repo. A secret-scanning gate is exactly the control that catches that class of mistake at PR time.

## What this does NOT do

It does **not** restore the fast-forward invariant in `gap-analysis/industral-production/dev-to-main/fast-forward-only-release-flow.md`. A cherry-pick copies the *content* under a new SHA; `main`'s original `d1d1e0c` is still absent from `dev`, so `main` remains a non-ancestor and `git merge --ff-only origin/dev` would still be rejected.

Restoring ancestry needs a rebase of `dev` onto `main` (verified conflict-free), which requires an admin to relax `dev`'s force-push protection. That is a separate operation.

## Follow-up worth raising with the platform team

The rollout targets each repo's **default branch**. While Continuum's default is `main`, every future pass will re-break the fast-forward invariant the release flow depends on. Either the rollout should target `dev` for this repo, or the default branch should change.
