### PR TITLE
fix(ci): restore secret scanning — replace deleted composite action

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -12,8 +12,17 @@ jobs:
   trufflehog-scan:
     runs-on: ubuntu-latest
     steps:
-      - name: Run TruffleHog Composite Action
-        uses: shyftlabs/global-devops-runner-template/.github/actions/trufflehog@main
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          # full history so the base..head diff can be walked
+          fetch-depth: 0
+
+      - name: Scan for secrets
+        # pinned to v3.96.0 by SHA; the previous composite action
+        # (shyftlabs/global-devops-runner-template) no longer exists
+        uses: trufflesecurity/trufflehog@6f3c981e7b77f235fd2702dd74af25fc4b72bf11
         with:
           base: ${{ github.event.pull_request.base.sha }}
           head: ${{ github.event.pull_request.head.sha }}
+          extra_args: --results=verified,unknown


### PR DESCRIPTION
## Problem

`security-scan.yml` has failed on **every PR** since it was added:

```
##[error]Unable to resolve action `shyftlabs/global-devops-runner-template`, not found
```

That repo does not exist — a token with org access to other private repos (`shyftlabs/shyftos-devops-local`, `shyftlabs/global-devops-helm-values`) still gets a 404 on it, so it was deleted or renamed rather than being a permissions problem.

Net effect: **the repo has had no working secret scanning at all**, and a permanently-red check trains reviewers to ignore CI.

## Fix

Use the upstream TruffleHog action, **pinned by commit SHA** (`6f3c981` = v3.96.0) rather than a floating `@main` tag — a floating third-party action is a supply-chain risk, which matters more than usual here given #85 just closed 13 security findings.

Also adds the `actions/checkout` step the composite action used to perform internally, with `fetch-depth: 0` so the `base..head` diff can actually be walked.

`--results=verified,unknown` reports verified secrets plus unverifiable candidates, and skips confirmed false positives.

## Note for DevOps

If `global-devops-runner-template` is restored under a new name, switching back is a one-line change. This restores working coverage in the meantime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)