### PR TITLE
Keep live objects off spans (OOMKill), fix langfuse postgres port map…

### DIFF
--- a/src/continuum/infra/docker-compose.yml
+++ b/src/continuum/infra/docker-compose.yml
@@ -241,7 +241,11 @@ services:
       TZ: UTC
       PGTZ: UTC
     ports:
-      - 127.0.0.1:${LANGFUSE_POSTGRES_PORT:-5433}:5433
+      # Container side is 5432 — the port postgres actually listens on. Nothing
+      # here sets PGPORT or overrides `command`, so the image uses its default.
+      # The 5433 on the host side is only to avoid colliding with a local
+      # postgres install, and is unrelated to the container's port.
+      - 127.0.0.1:${LANGFUSE_POSTGRES_PORT:-5433}:5432
     volumes:
       - langfuse_postgres_data:/var/lib/postgresql/data
 

--- a/src/continuum/observability/decorators.py
+++ b/src/continuum/observability/decorators.py
@@ -56,12 +56,41 @@ def _record_observe_exception(span: Any, span_name: str, e: BaseException) -> No
     report_error(e, context=f"observe.{span_name}", trace_id=get_current_trace_id())
 
 
+def _is_method(func: Callable[..., Any]) -> bool:
+    """Whether ``func`` was defined in a class body (so arg 0 is the receiver).
+
+    Decided from ``__qualname__`` rather than from the arguments: a method's
+    qualname is ``Owner.name``, while a nested plain function's is
+    ``...<locals>.name``. ``func`` is always the undecorated function here —
+    @observe is applied inside the class body, before any binding happens — so
+    its qualname still names the owning class.
+    """
+    parts = func.__qualname__.split(".")
+    return len(parts) > 1 and parts[-2] != "<locals>"
+
+
 def _get_function_input(func: Callable[..., Any], args: tuple, kwargs: dict) -> dict[str, Any]:
-    """Extract function input as a dictionary."""
+    """Extract function input as a dictionary.
+
+    The receiver (``self``/``cls``) is dropped. It is not input — it is a live
+    handle on the running object, and capturing it put the whole object graph
+    on the span: a ToolExecutor reached telemetry as 93 KB of tool_registry and
+    _run_artifacts, which OOMKilled the process holding it.
+
+    Both conditions are required. Position alone would strip the first argument
+    of any function; name alone would corrupt a plain function that legitimately
+    takes a parameter called ``self``.
+    """
     sig = inspect.signature(func)
     bound = sig.bind(*args, **kwargs)
     bound.apply_defaults()
-    return dict(bound.arguments)
+    arguments = dict(bound.arguments)
+
+    params = list(sig.parameters)
+    if params and params[0] in ("self", "cls") and _is_method(func):
+        arguments.pop(params[0], None)
+
+    return arguments
 
 
 def _serialize_output(output: Any) -> Any:

--- a/src/continuum/observability/trace_context.py
+++ b/src/continuum/observability/trace_context.py
@@ -553,7 +553,16 @@ def truncate_data(data: Any, max_size: int = MAX_TRACE_DATA_SIZE) -> Any:
         json_str = json.dumps(data, default=str)
 
         if len(json_str) <= max_size:
-            return data
+            # Return what was MEASURED, not the original. `default=str` renders
+            # anything json cannot encode as a short repr, so a live object
+            # measures ~50 bytes and clears the limit — while the object itself
+            # goes on to be expanded by the backend's serializer, which walks
+            # __dict__ recursively (93 KB from one ToolExecutor, then OOMKill).
+            # Round-tripping returns the flattened form the check actually
+            # validated, so nothing reaches telemetry that was never weighed.
+            # Note this normalises as JSON does: tuples become lists, non-string
+            # dict keys become strings — which is what the wire carries anyway.
+            return json.loads(json_str)
 
         # Truncate string representation
         truncated = json_str[: max_size - 50]  # Leave room for truncation message

--- a/tests/unit/observability/test_span_input_capture.py
+++ b/tests/unit/observability/test_span_input_capture.py
@@ -1,0 +1,141 @@
+"""
+Span payloads must be inert data, never live objects.
+
+Two defects composed into an OOMKill in a downstream service (v1.2.0): every
+decorated method captured `self`, and the size guard measured a stand-in for
+the object rather than the object, then returned the object it had never
+actually weighed. A ToolExecutor whose repr measured 49 bytes expanded to
+93,772 bytes once the telemetry backend walked its __dict__.
+
+Both halves are tested independently: either one alone is enough to put a live
+object on the wire, so neither may regress on the strength of the other.
+"""
+
+from __future__ import annotations
+
+import json
+
+from continuum.observability.decorators import _get_function_input, observe
+from continuum.observability.trace_context import MAX_TRACE_DATA_SIZE, truncate_data
+
+
+class Live:
+    """Stand-in for a heavy runtime object (ToolExecutor, LLMClient, ...).
+
+    Self-referential on purpose: a naive deep copy or recursive walk of this
+    must not be what protects us.
+    """
+
+    def __init__(self, payload: str = "x"):
+        self.peer = self
+        self.payload = payload
+
+
+class TestGetFunctionInputDropsSelf:
+    """Defect 1 — the capture helper bound `self` along with the arguments."""
+
+    def test_self_is_not_captured_from_a_bound_method(self):
+        class Service:
+            def handle(self, job_id: str, retries: int = 0) -> None: ...
+
+        captured = _get_function_input(Service.handle, (Service(), "job-1"), {})
+
+        assert "self" not in captured
+        assert captured == {"job_id": "job-1", "retries": 0}
+
+    def test_cls_is_not_captured_from_a_classmethod(self):
+        class Service:
+            @classmethod
+            def build(cls, name: str) -> None: ...
+
+        captured = _get_function_input(Service.build.__func__, (Service, "svc"), {})
+
+        assert "cls" not in captured
+        assert captured == {"name": "svc"}
+
+    def test_plain_function_arguments_are_untouched(self):
+        # The fix must key on the receiver position, not on the name — a plain
+        # function is entitled to a parameter called `self`.
+        def transform(self, data: dict) -> None: ...
+
+        captured = _get_function_input(transform, ("not-a-receiver", {"k": "v"}), {})
+
+        assert captured == {"self": "not-a-receiver", "data": {"k": "v"}}
+
+    def test_decorated_method_puts_no_self_on_the_span(self):
+        seen: dict = {}
+
+        class Service:
+            def __init__(self):
+                self.registry = {"tool": "definition"}
+
+            @observe(name="svc_call", capture_input=True)
+            def call(self, job_id: str) -> str:
+                return "done"
+
+        # SpanScope no-ops without a trace context, so assert on what the
+        # decorator built rather than on what was exported.
+        original = _get_function_input
+
+        def spy(func, args, kwargs):
+            seen.update(result := original(func, args, kwargs))
+            return result
+
+        import continuum.observability.decorators as decorators
+
+        decorators._get_function_input = spy
+        try:
+            Service().call("job-1")
+        finally:
+            decorators._get_function_input = original
+
+        assert "self" not in seen
+        assert seen == {"job_id": "job-1"}
+
+
+class TestTruncateDataReturnsWhatItMeasured:
+    """Defect 2 — the guard returned the original, not the flattened form."""
+
+    def test_live_object_does_not_survive(self):
+        out = truncate_data({"self": Live()})
+
+        assert not isinstance(out["self"], Live)
+        assert isinstance(out["self"], str)
+        assert "Live object at" in out["self"]
+
+    def test_return_value_is_json_serializable_without_a_default(self):
+        # The real defect: the returned value had never been proven encodable.
+        # json.dumps with no `default` is exactly the test the backend applies.
+        out = truncate_data({"executor": Live(), "job_id": "job-1"})
+
+        json.dumps(out)  # must not raise
+
+    def test_small_plain_data_is_returned_faithfully(self):
+        data = {"messages": [{"role": "user", "content": "hi"}], "n": 3, "ok": True}
+
+        assert truncate_data(data) == data
+
+    def test_oversized_data_still_truncates(self):
+        data = {"blob": "x" * (MAX_TRACE_DATA_SIZE * 2)}
+
+        out = truncate_data(data)
+
+        assert out["_truncated"] is True
+        assert out["_original_size"] > MAX_TRACE_DATA_SIZE
+
+    def test_unencodable_data_still_falls_back_to_a_string(self):
+        # Keys json cannot encode at all — the existing except branch owns this
+        # and must keep owning it.
+        out = truncate_data({("tuple", "key"): Live()})
+
+        assert isinstance(out, str)
+
+    def test_nested_live_object_does_not_survive(self):
+        # Dropping `self` alone would not catch this: a caller can pass a live
+        # object as an ordinary argument.
+        out = truncate_data({"ctx": {"deep": [Live()]}})
+
+        json.dumps(out)  # must not raise
+
+    def test_none_is_preserved(self):
+        assert truncate_data(None) is None


### PR DESCRIPTION
…ping (#93)

* fix(infra): publish langfuse postgres on the port it listens on

The postgres service mapped host 5433 to container 5433, but the image listens on 5432 — nothing sets PGPORT or overrides `command`. Verified in the running container: only 0x1538 (5432) is bound.

Host access was therefore dead. `psql` on 127.0.0.1:5433 returned "Connection refused"; a bare `nc -z` reported the port open, because docker-proxy binds the host side regardless of what is listening inside, which is why this went unnoticed. Langfuse was unaffected throughout — it reaches the DB at postgres:5432 over the compose network and never uses the published port.

Container side is now 5432, matching postgres-temporal directly below, which already had it right. The host side stays 5433 to avoid colliding with a local postgres install; a comment records why the two differ.

Verified by recreating the container: inet_server_port() over 127.0.0.1:5433 returns 5432, the volume's 64 tables survived, and both langfuse containers stayed up.



* fix(observability): keep live objects off spans (OOMKill)

Two defects composed into an OOMKill downstream: four on a dev cluster in one day, ~2 min from trigger to death.

1. _get_function_input returned dict(bound.arguments), which includes the receiver. All 32 decorated sites in the SDK are instance methods and none opt out of input capture, so every span carried a live handle on the running object — LLMClient, ToolExecutor, the Redis session providers.

2. truncate_data measured with json.dumps(data, default=str), then returned `data`. default=str renders an unencodable object as a ~50-byte repr, so a live object cleared the 10 KiB limit — and the object, not the repr, was returned. The guard ran twice per span and was a no-op both times, because both times it weighed the same stand-in.

Together: a ToolExecutor measured 49 bytes and reached the backend, whose serializer walks __dict__ recursively and expanded it to 93,772 bytes (tool_registry 18,335 + _run_artifacts 74,930). Redaction does not help — spans use mask_secrets=False, which passes data through untouched.

Fixed both, since either alone still admits a live object: dropping the receiver does nothing about one passed as an ordinary argument, and a sound size guard would still ship the receiver's flattened internals every call.

_get_function_input now drops arg 0 only when the first parameter is self/cls AND __qualname__ shows a class body — position alone would strip any function's first argument, name alone would corrupt a plain function that legitimately takes a `self` parameter.

truncate_data now returns json.loads(json_str) — the form it actually measured. This normalises as JSON does (tuples to lists, non-string dict keys to strings), which is what the wire carried regardless. Unencodable input keeps falling through to the existing str() branch.

Verified: the reporter's repro assert now fails as it should; a real span for a ToolExecutor-shaped object carries 53 bytes of arguments instead of the object. 11 new tests, 1928 unit tests pass, ruff clean, mypy unchanged at its pre-existing 23 errors in these files (none in the changed regions).



---------

<!--
Thanks for the PR! Please fill in the sections below.
PR title must follow Conventional Commits: feat: | fix: | docs: | chore: | test: | perf: | ci:
PRs target `dev` (not `main`). See CONTRIBUTING.md for the branch model.
-->

## What

<!-- One-line summary of the change. -->

## Why

<!-- The reason for the change — link the issue if there is one (e.g. Closes #123). -->

## How tested

<!-- unit / integration / manual. Paste output or a screenshot if helpful. -->

## Type of change

- [ ] `feat` — new user-facing feature
- [ ] `fix` — bug fix
- [ ] `docs` — documentation only
- [ ] `chore` — refactor / deps / tooling
- [ ] `test` — test-only change
- [ ] `perf` — performance improvement
- [ ] `ci` — CI / build config

## Checklist

- [ ] PR targets `dev` (not `main`)
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] Every commit is signed off (`git commit -s`) per the [DCO](https://developercertificate.org)
- [ ] `pytest` passes locally
- [ ] `ruff check .` passes
- [ ] `mypy src/orchestrator` clean for the code you changed (not yet a CI gate — repo-wide type debt tracked separately)
- [ ] Tests added or updated for the change
- [ ] Docs updated if user-facing
- [ ] `CHANGELOG.md` entry added under `## [Unreleased]` if user-facing
- [ ] No secrets, credentials, or `.env` files committed
