### PR TITLE
Gateway latency probe, extra_body threading, and tool-call provider extras

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -185,3 +185,12 @@ playground/**/tool-trust/
 # tree that predates the move does not suddenly show them as untracked.
 playground/**/tool-pins.json
 playground/**/.tool-pins-last-seen.json
+
+# Latency probe output (src/continuum/llm/timing_probe.py). Every record carries
+# turn_meta.question — the user's actual prompt — so this must never be
+# committed. Regenerate it instead: CONTINUUM_TIMING_LOG=1.
+#
+# No slash in the pattern, so git matches it as a basename at every depth — a
+# `**/` twin would be redundant here, unlike the anchored `playground/**/...`
+# rules above which do need it.
+continuum-timing.jsonl

--- a/.gitignore
+++ b/.gitignore
@@ -193,4 +193,7 @@ playground/**/.tool-pins-last-seen.json
 # No slash in the pattern, so git matches it as a basename at every depth — a
 # `**/` twin would be redundant here, unlike the anchored `playground/**/...`
 # rules above which do need it.
-continuum-timing.jsonl
+# Glob, not the exact name: parked/renamed variants (continuum-timing.mixed.jsonl,
+# .armA-nogap.jsonl, per-run archives) carry the same turn_meta.question payload
+# and were NOT matched by the exact-name rule this replaces.
+continuum-timing*.jsonl

--- a/playground/gateway-local-shop/agent.py
+++ b/playground/gateway-local-shop/agent.py
@@ -8,6 +8,7 @@ but against a local MCP server instead of the remote one.
 import json
 import os
 import sys
+import uuid
 from collections.abc import AsyncGenerator
 from typing import Any
 
@@ -28,6 +29,7 @@ from continuum import (
 )
 from continuum.agent.types import EventType
 from continuum.core.container import Container, get_container
+from continuum.llm.timing_probe import timing_turn
 from continuum.core.lifecycle import OrchestratorLifecycle, get_lifecycle_manager
 from continuum.exceptions import InsecureConfigurationError
 from continuum.tools.tool_attention.config import ToolAttentionConfig
@@ -46,6 +48,31 @@ logger = get_logger(__name__)
 # here would fire the "NO totals" warning on every successful add.
 _CART_TOOLS = {"view_cart", "checkout"}
 _TOTAL_KEYS = {"total", "subtotal", "total_cents", "subtotal_cents", "taxes", "tax_cents"}
+
+# Per-turn latency tagging. Both helpers are cheap and unconditional — the probe
+# itself decides whether anything is written, so the agent path does not have to
+# branch on whether measurement is switched on.
+_TURN_QUESTION_MAX = 120
+
+
+def _new_turn_id() -> str:
+    """Short, unique id for one user question."""
+    return uuid.uuid4().hex[:12]
+
+
+def _turn_meta(message: str, config: ShopConfig, entrypoint: str) -> dict[str, Any]:
+    """What the rollup needs in order to be readable.
+
+    The question is truncated: it is repeated on every record belonging to the
+    turn, and a long paste would dominate the log without telling the reader more
+    than its first line does.
+    """
+    q = " ".join(message.split())
+    return {
+        "question": q[:_TURN_QUESTION_MAX] + ("…" if len(q) > _TURN_QUESTION_MAX else ""),
+        "agent_model": config.agent_model,
+        "entrypoint": entrypoint,
+    }
 
 
 def _raw_tool_name(tool_name: str) -> str:
@@ -276,13 +303,19 @@ class LocalShopAgent:
                 except Exception as e:
                     logger.warning(f"Session init failed for user {user_id}: {e}")
 
+        # One user question fans out into several gateway calls — the agent loop
+        # re-enters the model after each tool result. The probe records one line
+        # per HTTP call, so without a shared id there is no way to add them back
+        # up into "what did this question cost". Inert unless CONTINUUM_TIMING_LOG
+        # is set: the context manager only sets a contextvar.
         try:
-            response = await self._runner.run(
-                agent=self._agent,
-                input=message,
-                session_id=session_id,
-                user_id=user_id,
-            )
+            with timing_turn(_new_turn_id(), meta=_turn_meta(message, self.config, "chat")):
+                response = await self._runner.run(
+                    agent=self._agent,
+                    input=message,
+                    session_id=session_id,
+                    user_id=user_id,
+                )
             return response.content or ""
         except Exception as e:
             logger.error(f"Chat error: {e}")
@@ -334,31 +367,38 @@ class LocalShopAgent:
 
         yield f"data: {json.dumps({'type': 'start', 'session_id': session_id, 'user_id': user_id})}\n\n"
 
+        # See chat(). Note the probe's streaming caveat: httpx fires its response
+        # hook when headers arrive, so client_ms on this path is time-to-headers
+        # and the gateway usually cannot stamp x-aura-timing onto a body that is
+        # already flowing. Measure with the UI's Stream toggle OFF.
         try:
-            async for event in self._runner.run_stream(
-                agent=self._agent,
-                input=message,
-                session_id=session_id,
-                user_id=user_id,
+            with timing_turn(
+                _new_turn_id(), meta=_turn_meta(message, self.config, "chat_stream")
             ):
-                if event.type == EventType.CONTENT_DELTA:
-                    content = event.data.get("content", "")
-                    if content:
-                        yield f"data: {json.dumps({'type': 'content', 'content': content})}\n\n"
+                async for event in self._runner.run_stream(
+                    agent=self._agent,
+                    input=message,
+                    session_id=session_id,
+                    user_id=user_id,
+                ):
+                    if event.type == EventType.CONTENT_DELTA:
+                        content = event.data.get("content", "")
+                        if content:
+                            yield f"data: {json.dumps({'type': 'content', 'content': content})}\n\n"
 
-                elif event.type == EventType.TOOL_CALL_START:
-                    yield f"data: {json.dumps({'type': 'tool_call', 'tool_name': event.data.get('tool_name', ''), 'status': 'start'})}\n\n"
+                    elif event.type == EventType.TOOL_CALL_START:
+                        yield f"data: {json.dumps({'type': 'tool_call', 'tool_name': event.data.get('tool_name', ''), 'status': 'start'})}\n\n"
 
-                elif event.type == EventType.TOOL_CALL_END:
-                    yield f"data: {json.dumps({'type': 'tool_call', 'tool_name': event.data.get('tool_name', ''), 'status': 'end'})}\n\n"
+                    elif event.type == EventType.TOOL_CALL_END:
+                        yield f"data: {json.dumps({'type': 'tool_call', 'tool_name': event.data.get('tool_name', ''), 'status': 'end'})}\n\n"
 
-                elif event.type == EventType.RUN_ERROR:
-                    yield f"data: {json.dumps({'type': 'error', 'error': event.data.get('error', 'Unknown error')})}\n\n"
-                    break
+                    elif event.type == EventType.RUN_ERROR:
+                        yield f"data: {json.dumps({'type': 'error', 'error': event.data.get('error', 'Unknown error')})}\n\n"
+                        break
 
-                elif event.type == EventType.RUN_END:
-                    yield f"data: {json.dumps({'type': 'done'})}\n\n"
-                    break
+                    elif event.type == EventType.RUN_END:
+                        yield f"data: {json.dumps({'type': 'done'})}\n\n"
+                        break
 
         except Exception as e:
             logger.error(f"Stream error: {e}")

--- a/playground/gateway-local-shop/agent.py
+++ b/playground/gateway-local-shop/agent.py
@@ -231,6 +231,7 @@ class LocalShopAgent:
             instructions=instructions,
             model=self.config.agent_model,
             temperature=self.config.agent_temperature,
+            extra_body=self.config.extra_body,
             gateway_mode=self.config.gateway_mode,
             tools=self._tools,
             tool_executor=self._tool_executor,

--- a/playground/gateway-local-shop/agent.py
+++ b/playground/gateway-local-shop/agent.py
@@ -29,9 +29,9 @@ from continuum import (
 )
 from continuum.agent.types import EventType
 from continuum.core.container import Container, get_container
-from continuum.llm.timing_probe import timing_turn
 from continuum.core.lifecycle import OrchestratorLifecycle, get_lifecycle_manager
 from continuum.exceptions import InsecureConfigurationError
+from continuum.llm.timing_probe import timing_turn
 from continuum.tools.tool_attention.config import ToolAttentionConfig
 from continuum.tools.types import ToolContextConfig, ToolContextVariable
 from continuum.tools.util import NAMESPACE_SEPARATOR
@@ -376,9 +376,7 @@ class LocalShopAgent:
         # and the gateway usually cannot stamp x-aura-timing onto a body that is
         # already flowing. Measure with the UI's Stream toggle OFF.
         try:
-            with timing_turn(
-                _new_turn_id(), meta=_turn_meta(message, self.config, "chat_stream")
-            ):
+            with timing_turn(_new_turn_id(), meta=_turn_meta(message, self.config, "chat_stream")):
                 async for event in self._runner.run_stream(
                     agent=self._agent,
                     input=message,

--- a/playground/gateway-local-shop/agent.py
+++ b/playground/gateway-local-shop/agent.py
@@ -231,7 +231,10 @@ class LocalShopAgent:
             instructions=instructions,
             model=self.config.agent_model,
             temperature=self.config.agent_temperature,
-            extra_body=self.config.extra_body,
+            # getattr: this playground config is edited constantly between
+            # experiments, and a commented-out field should degrade to "no extra
+            # params" rather than crash the agent at startup.
+            extra_body=getattr(self.config, "extra_body", None),
             gateway_mode=self.config.gateway_mode,
             tools=self._tools,
             tool_executor=self._tool_executor,

--- a/playground/gateway-local-shop/config.py
+++ b/playground/gateway-local-shop/config.py
@@ -54,7 +54,8 @@ class ShopConfig:
     # The `openai/` prefix is correct in both modes: the gateway needs a provider
     # id, and with no gateway the default OpenAI provider strips it before the
     # call. Needs OPENAI_API_KEY in the root .env.
-    agent_model: str = "openai/gpt-5-mini"  # "gpt-4o-mini", "anthropic/claude-opus-4-8", "auto/mid"
+    agent_model: str = "openai/gpt-5-nano"#"openai/gpt-5-mini"  # "gpt-4o-mini", "anthropic/claude-opus-4-8", "auto/mid"
+    extra_body = {"reasoning_effort": "high"}
     agent_temperature: float = 0.7
     max_turns: int = 10
 

--- a/playground/gateway-local-shop/config.py
+++ b/playground/gateway-local-shop/config.py
@@ -54,8 +54,13 @@ class ShopConfig:
     # The `openai/` prefix is correct in both modes: the gateway needs a provider
     # id, and with no gateway the default OpenAI provider strips it before the
     # call. Needs OPENAI_API_KEY in the root .env.
-    agent_model: str = "openai/gpt-5-nano"#"openai/gpt-5-mini"  # "gpt-4o-mini", "anthropic/claude-opus-4-8", "auto/mid"
-    extra_body = {"reasoning_effort": "high"}
+    agent_model: str = "openai/gpt-5-mini"  # "gpt-4o-mini", "anthropic/claude-opus-4-8", "auto/mid"
+    # Provider-specific body params, e.g. {"reasoning_effort": "high"}.
+    # Leave None when agent_model is an `auto/*` tier: the gateway routes to an
+    # effort ALIAS (auto/mid -> gpt-5-nano-high) which sets reasoning_effort
+    # itself, and a caller control that conflicts with an alias is rejected
+    # rather than silently overriding the pin.
+    extra_body: dict | None = None
     agent_temperature: float = 0.7
     max_turns: int = 10
 

--- a/playground/gateway-local-shop/timing_report.py
+++ b/playground/gateway-local-shop/timing_report.py
@@ -186,10 +186,14 @@ def main() -> None:
         print(f"ACROSS {len(turns)} TURNS")
         print("-" * 78)
         print(f"  {'':<26}{'median':>10}{'min':>10}{'max':>10}")
-        print(f"  {'gateway calls per turn':<26}{st.median(per_turn_calls):>10.1f}"
-              f"{min(per_turn_calls):>10}{max(per_turn_calls):>10}")
-        print(f"  {'client_ms per turn':<26}{st.median(per_turn_client):>10.1f}"
-              f"{min(per_turn_client):>10.1f}{max(per_turn_client):>10.1f}")
+        print(
+            f"  {'gateway calls per turn':<26}{st.median(per_turn_calls):>10.1f}"
+            f"{min(per_turn_calls):>10}{max(per_turn_calls):>10}"
+        )
+        print(
+            f"  {'client_ms per turn':<26}{st.median(per_turn_client):>10.1f}"
+            f"{min(per_turn_client):>10.1f}{max(per_turn_client):>10.1f}"
+        )
         for k in sorted(per_turn_phase, key=lambda k: -st.median(per_turn_phase[k])):
             v = per_turn_phase[k]
             print(f"  {k:<26}{st.median(v):>10.1f}{min(v):>10.1f}{max(v):>10.1f}")
@@ -197,7 +201,9 @@ def main() -> None:
         med_client = st.median(per_turn_client)
         med_cls = st.median(per_turn_phase.get("classifier_ms", [0]))
         if med_client and med_cls:
-            print(f"\n  classifier as a share of one user question: {med_cls / med_client * 100:.1f}%")
+            print(
+                f"\n  classifier as a share of one user question: {med_cls / med_client * 100:.1f}%"
+            )
     print()
 
 

--- a/playground/gateway-local-shop/timing_report.py
+++ b/playground/gateway-local-shop/timing_report.py
@@ -1,0 +1,205 @@
+"""Roll the per-call timing log up into per-user-question totals.
+
+The probe (src/continuum/llm/timing_probe.py) writes one JSON line per HTTP call
+to an LLM provider. One user question is several of those — the agent re-enters
+the model after every tool result — so the raw log cannot answer "what did this
+question cost". agent.py tags each turn with a shared id; this reads them back.
+
+    CONTINUUM_TIMING_LOG=1 python web.py          # collect
+    python timing_report.py                       # report
+
+Reads CONTINUUM_TIMING_LOG_PATH, or continuum-timing.jsonl in the working
+directory, or a path given as the first argument.
+
+Phases are NOT hardcoded here. Whatever numeric keys the gateway sent are
+summed, so a phase added to the gateway's registry shows up without editing this
+file — the same reason the gateway's own harness stopped keeping a hand-written
+field list.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import statistics as st
+import sys
+from collections import defaultdict
+from pathlib import Path
+from typing import Any
+
+DEFAULT_PATH = "continuum-timing.jsonl"
+
+# The gateway's phases are not a flat partition of the request — some contain
+# others, and summing them together double-counts. Three groups:
+#
+#   AGGREGATE   spans covering the whole request. Reported, never summed.
+#   NESTED      a strict subset of another phase. Shown indented under the
+#               phase that contains it, and excluded from the total.
+#   everything else — disjoint, and what the breakdown actually adds up.
+#
+# Verified against a live payload: classifier_llm_call_ms (3423.2) +
+# classifier_extract_ms (1.9) reconstructs classifier_ms (3429.0), and
+# provider_attempt_1_ms (1796.4) matches upstream_ms (1796.3) on a single-attempt
+# request — upstream_ms being the sum over attempts.
+AGGREGATE_PHASES = {"gateway_total_ms", "gateway_pre_upstream_ms"}
+
+NESTED_PHASES = {
+    "classifier_llm_call_ms": "classifier_ms",
+    "classifier_extract_ms": "classifier_ms",
+}
+
+
+def _parent_of(key: str) -> str | None:
+    """The phase that contains `key`, or None if it stands alone."""
+    if key in NESTED_PHASES:
+        return NESTED_PHASES[key]
+    # provider_attempt_N_ms are the per-attempt spans upstream_ms sums.
+    if key.startswith("provider_attempt_") and key.endswith("_ms"):
+        return "upstream_ms"
+    # request_shaping_N_ms are disjoint passes, not subsets — left to sum.
+    return None
+
+
+def load(path: Path) -> list[dict[str, Any]]:
+    if not path.exists():
+        sys.exit(f"no timing log at {path}. Run with CONTINUUM_TIMING_LOG=1 first.")
+    out = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            out.append(json.loads(line))
+        except json.JSONDecodeError:
+            continue
+    return out
+
+
+def main() -> None:
+    path = Path(
+        sys.argv[1]
+        if len(sys.argv) > 1
+        else os.environ.get("CONTINUUM_TIMING_LOG_PATH") or DEFAULT_PATH
+    )
+    records = load(path)
+
+    turns: dict[str | None, list[dict]] = defaultdict(list)
+    for r in records:
+        turns[r.get("turn_id")].append(r)
+
+    untagged = turns.pop(None, [])
+    if not turns:
+        sys.exit(
+            f"{len(records)} records, none carrying a turn_id. "
+            "Calls made outside chat()/chat_stream() are not tagged."
+        )
+
+    print(f"\n{len(records)} calls across {len(turns)} turns   ({path})")
+    if untagged:
+        print(f"  ({len(untagged)} untagged calls excluded — made outside a turn)")
+
+    per_turn_client: list[float] = []
+    per_turn_phase: dict[str, list[float]] = defaultdict(list)
+    per_turn_calls: list[int] = []
+
+    for tid, calls in turns.items():
+        calls.sort(key=lambda r: r.get("seq") or 0)
+        meta = next((c.get("turn_meta") for c in calls if c.get("turn_meta")), {}) or {}
+        client_total = sum(c.get("client_ms") or 0 for c in calls)
+
+        per_turn_client.append(client_total)
+        per_turn_calls.append(len(calls))
+
+        print("\n" + "=" * 78)
+        print(f"turn {tid}   {len(calls)} gateway calls   {client_total:.0f} ms total")
+        if meta.get("question"):
+            print(f'  "{meta["question"]}"   [{meta.get("agent_model", "?")}]')
+        print("-" * 78)
+        print(f"  {'#':>2}  {'client_ms':>10}  {'gateway':>9}  {'upstream':>9}  {'classifier':>11}")
+
+        totals: dict[str, float] = defaultdict(float)
+        skipped: list[tuple[Any, dict]] = []
+        for c in calls:
+            t = c.get("timing") or {}
+            for k, v in t.items():
+                if isinstance(v, (int, float)):
+                    totals[k] += v
+
+            # A call that ran prompt extraction but produced no classifier_ms was
+            # not "cheap" — the gateway found no user text and skipped
+            # classification entirely, routing with no complexity signal. Read as
+            # a saving it flatters the numbers; flag it instead.
+            cls = t.get("classifier_ms")
+            req = c.get("request") or {}
+            if cls is None and "classifier_extract_ms" in t:
+                skipped.append((c.get("seq"), req))
+
+            print(
+                f"  {c.get('seq', '?'):>2}  {c.get('client_ms') or 0:>10.1f}"
+                f"  {t.get('gateway_total_ms', 0):>9.1f}"
+                f"  {t.get('upstream_ms', 0):>9.1f}"
+                f"  {(f'{cls:.1f}' if cls is not None else 'skipped'):>11}"
+                f"   {'/'.join(req.get('roles') or []) or '?'}"
+            )
+
+        for seq, req in skipped:
+            why = (
+                f"declared complexity={req['declared_complexity']!r}"
+                if req.get("declared_complexity")
+                else f"no user text (last user message: {req.get('last_user_chars', '?')} chars"
+                f", roles {req.get('roles')})"
+            )
+            print(f"\n  !! call {seq} was NOT classified — {why}")
+            print("     routed with no complexity signal, and no x-aura-classification header.")
+
+        for k, v in totals.items():
+            per_turn_phase[k].append(v)
+
+        disjoint = {
+            k: v
+            for k, v in totals.items()
+            if k not in AGGREGATE_PHASES and _parent_of(k) is None and v >= 0.05
+        }
+        children: dict[str, list[tuple[str, float]]] = defaultdict(list)
+        for k, v in totals.items():
+            parent = _parent_of(k)
+            if parent and v >= 0.05:
+                children[parent].append((k, v))
+
+        if disjoint:
+            print(f"\n  where the {client_total:.0f} ms went (summed across the turn):")
+            for k, v in sorted(disjoint.items(), key=lambda kv: -kv[1]):
+                share = v / client_total * 100 if client_total else 0
+                bar = "█" * max(0, min(40, round(share / 2.5)))
+                print(f"    {k:<26}{v:>9.1f} ms  {share:>5.1f}%  {bar}")
+                for ck, cv in sorted(children.get(k, []), key=lambda kv: -kv[1]):
+                    print(f"      └ {ck:<22}{cv:>9.1f} ms")
+            named = sum(disjoint.values())
+            rest = client_total - named
+            print(
+                f"    {'(client-side + untimed)':<26}{rest:>9.1f} ms"
+                f"  {rest / client_total * 100 if client_total else 0:>5.1f}%"
+            )
+
+    if len(turns) > 1:
+        print("\n" + "=" * 78)
+        print(f"ACROSS {len(turns)} TURNS")
+        print("-" * 78)
+        print(f"  {'':<26}{'median':>10}{'min':>10}{'max':>10}")
+        print(f"  {'gateway calls per turn':<26}{st.median(per_turn_calls):>10.1f}"
+              f"{min(per_turn_calls):>10}{max(per_turn_calls):>10}")
+        print(f"  {'client_ms per turn':<26}{st.median(per_turn_client):>10.1f}"
+              f"{min(per_turn_client):>10.1f}{max(per_turn_client):>10.1f}")
+        for k in sorted(per_turn_phase, key=lambda k: -st.median(per_turn_phase[k])):
+            v = per_turn_phase[k]
+            print(f"  {k:<26}{st.median(v):>10.1f}{min(v):>10.1f}{max(v):>10.1f}")
+
+        med_client = st.median(per_turn_client)
+        med_cls = st.median(per_turn_phase.get("classifier_ms", [0]))
+        if med_client and med_cls:
+            print(f"\n  classifier as a share of one user question: {med_cls / med_client * 100:.1f}%")
+    print()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/continuum/agent/base.py
+++ b/src/continuum/agent/base.py
@@ -117,6 +117,10 @@ class BaseAgent:
     # None omits temperature from LLM calls (for providers/models that reject it).
     temperature: float | None = 0.7
     max_tokens: int | None = None
+    # Provider-specific body params the SDK has no first-class field for —
+    # e.g. {"reasoning_effort": "high"} for the gpt-5 family. Passed through
+    # verbatim as the OpenAI SDK's `extra_body`; None omits it entirely.
+    extra_body: dict[str, Any] | None = None
     gateway_mode: str | None = (
         None  # "strict" | "modest" | "quality" — overrides SMART_GATEWAY_DEFAULT_MODE
     )
@@ -490,6 +494,7 @@ class BaseAgent:
             "model": self.model,
             "temperature": self.temperature,
             "max_tokens": self.max_tokens,
+            "extra_body": copy.deepcopy(self.extra_body),
             "tools": copy.deepcopy(self.tools),
             "tool_executor": self.tool_executor,
             "mcp_servers": list(self.mcp_servers),  # shallow OK — server instances are shared
@@ -534,6 +539,7 @@ class BaseAgent:
             "model": self.model,
             "temperature": self.temperature,
             "max_tokens": self.max_tokens,
+            "extra_body": copy.deepcopy(self.extra_body),
             "tools": [t if isinstance(t, dict) else str(t) for t in self.tools],
             "handoffs": [
                 {

--- a/src/continuum/llm/config.py
+++ b/src/continuum/llm/config.py
@@ -114,6 +114,10 @@ class LLMConfig(BaseModel):
             temperature=agent.temperature,
             max_tokens=agent.max_tokens,
             gateway_router_mode=getattr(agent, "gateway_mode", None),
+            # getattr rather than agent.extra_body: this classmethod is called with
+            # anything BaseAgent-shaped, including test doubles and subclasses that
+            # predate the field. Missing => None => the SDK call is unchanged.
+            extra_body=getattr(agent, "extra_body", None),
         )
 
         if agent.enable_json_mode:

--- a/src/continuum/llm/providers/gemini_provider.py
+++ b/src/continuum/llm/providers/gemini_provider.py
@@ -26,7 +26,13 @@ from continuum.llm.exceptions import (
     LLMTimeoutError,
 )
 from continuum.llm.providers.base import BaseProvider
-from continuum.llm.types import FunctionCall, LLMResponse, StreamChunk, ToolCall
+from continuum.llm.types import (
+    FunctionCall,
+    LLMResponse,
+    StreamChunk,
+    ToolCall,
+    provider_extras,
+)
 from continuum.logging import get_logger
 
 logger = get_logger(__name__)
@@ -157,10 +163,10 @@ class GeminiProvider(BaseProvider):
             raise
 
     @staticmethod
-    def _accumulate_tool_call(acc: dict[int, dict[str, str]], raw_tc: Any) -> None:
+    def _accumulate_tool_call(acc: dict[int, dict[str, Any]], raw_tc: Any) -> None:
         idx = raw_tc.index
         if idx not in acc:
-            acc[idx] = {"id": "", "name": "", "arguments": ""}
+            acc[idx] = {"id": "", "name": "", "arguments": "", "extras": {}}
         if raw_tc.id:
             acc[idx]["id"] = raw_tc.id
         if raw_tc.function:
@@ -168,14 +174,21 @@ class GeminiProvider(BaseProvider):
                 acc[idx]["name"] += raw_tc.function.name
             if raw_tc.function.arguments:
                 acc[idx]["arguments"] += raw_tc.function.arguments
+            # Gemini signs each function call with a thought_signature and
+            # requires it back next turn; it arrives on one delta only.
+            acc[idx]["extras"].update(provider_extras(raw_tc.function))
 
     @staticmethod
-    def _build_tool_calls_from_acc(acc: dict[int, dict[str, str]]) -> list[ToolCall]:
+    def _build_tool_calls_from_acc(acc: dict[int, dict[str, Any]]) -> list[ToolCall]:
         return [
             ToolCall(
                 id=acc[i]["id"],
                 type="function",
-                function=FunctionCall(name=acc[i]["name"], arguments=acc[i]["arguments"]),
+                function=FunctionCall(
+                    name=acc[i]["name"],
+                    arguments=acc[i]["arguments"],
+                    **acc[i].get("extras", {}),
+                ),
             )
             for i in sorted(acc)
         ]

--- a/src/continuum/llm/providers/openai_provider.py
+++ b/src/continuum/llm/providers/openai_provider.py
@@ -29,7 +29,13 @@ from continuum.llm.structured_output import (
     unwrap_structured_tool_call,
 )
 from continuum.llm.timing_probe import build_async_http_client, build_sync_http_client
-from continuum.llm.types import FunctionCall, LLMResponse, StreamChunk, ToolCall
+from continuum.llm.types import (
+    FunctionCall,
+    LLMResponse,
+    StreamChunk,
+    ToolCall,
+    provider_extras,
+)
 from continuum.logging import get_logger
 
 logger = get_logger(__name__)
@@ -450,11 +456,11 @@ class OpenAIProvider(BaseProvider):
             raise
 
     @staticmethod
-    def _accumulate_tool_call(acc: dict[int, dict[str, str]], raw_tc: Any) -> None:
+    def _accumulate_tool_call(acc: dict[int, dict[str, Any]], raw_tc: Any) -> None:
         """Merge one raw OpenAI tool-call delta into the accumulator dict."""
         idx = raw_tc.index
         if idx not in acc:
-            acc[idx] = {"id": "", "name": "", "arguments": ""}
+            acc[idx] = {"id": "", "name": "", "arguments": "", "extras": {}}
         if raw_tc.id:
             acc[idx]["id"] = raw_tc.id
         if raw_tc.function:
@@ -462,14 +468,22 @@ class OpenAIProvider(BaseProvider):
                 acc[idx]["name"] += raw_tc.function.name
             if raw_tc.function.arguments:
                 acc[idx]["arguments"] += raw_tc.function.arguments
+            # Provider state (e.g. Gemini's thought_signature) rides on whichever
+            # delta carries it — usually the first — while later deltas stream
+            # only argument text. Merge rather than overwrite so it isn't lost.
+            acc[idx]["extras"].update(provider_extras(raw_tc.function))
 
     @staticmethod
-    def _build_tool_calls_from_acc(acc: dict[int, dict[str, str]]) -> list[ToolCall]:
+    def _build_tool_calls_from_acc(acc: dict[int, dict[str, Any]]) -> list[ToolCall]:
         return [
             ToolCall(
                 id=acc[i]["id"],
                 type="function",
-                function=FunctionCall(name=acc[i]["name"], arguments=acc[i]["arguments"]),
+                function=FunctionCall(
+                    name=acc[i]["name"],
+                    arguments=acc[i]["arguments"],
+                    **acc[i].get("extras", {}),
+                ),
             )
             for i in sorted(acc)
         ]

--- a/src/continuum/llm/providers/openai_provider.py
+++ b/src/continuum/llm/providers/openai_provider.py
@@ -28,6 +28,7 @@ from continuum.llm.structured_output import (
     forces_structured_tool,
     unwrap_structured_tool_call,
 )
+from continuum.llm.timing_probe import build_async_http_client, build_sync_http_client
 from continuum.llm.types import FunctionCall, LLMResponse, StreamChunk, ToolCall
 from continuum.logging import get_logger
 
@@ -123,8 +124,22 @@ class OpenAIProvider(BaseProvider):
         if default_headers:
             kwargs["default_headers"] = default_headers
 
-        self._client = OpenAI(**kwargs)
-        self._async_client = AsyncOpenAI(**kwargs)
+        # Client-side latency probe. Both builders return None unless
+        # CONTINUUM_TIMING_LOG is set, in which case the two constructions below
+        # are exactly what they were before it existed.
+        #
+        # Applied per-client rather than folded into `kwargs`: the sync and async
+        # SDK clients need a sync and an async httpx client respectively, so one
+        # shared dict cannot carry both.
+        sync_kwargs = dict(kwargs)
+        async_kwargs = dict(kwargs)
+        if (sync_http := build_sync_http_client()) is not None:
+            sync_kwargs["http_client"] = sync_http
+        if (async_http := build_async_http_client()) is not None:
+            async_kwargs["http_client"] = async_http
+
+        self._client = OpenAI(**sync_kwargs)
+        self._async_client = AsyncOpenAI(**async_kwargs)
 
     @staticmethod
     def supports_native_schema() -> bool:

--- a/src/continuum/llm/timing_probe.py
+++ b/src/continuum/llm/timing_probe.py
@@ -60,10 +60,11 @@ import json
 import os
 import threading
 import time
+from collections.abc import Iterator
 from contextlib import contextmanager
 from contextvars import ContextVar
-from datetime import datetime, timezone
-from typing import Any, Iterator
+from datetime import UTC, datetime
+from typing import Any
 
 import httpx
 
@@ -104,7 +105,7 @@ _START_KEY = "continuum_probe_start"
 # which is still a usable per-call log.
 _turn_id: ContextVar[str | None] = ContextVar("continuum_timing_turn_id", default=None)
 _turn_seq: ContextVar[int] = ContextVar("continuum_timing_turn_seq", default=0)
-_turn_meta: ContextVar["dict[str, Any] | None"] = ContextVar(
+_turn_meta: ContextVar[dict[str, Any] | None] = ContextVar(
     "continuum_timing_turn_meta", default=None
 )
 
@@ -174,9 +175,7 @@ def _content_text(content: Any) -> str:
         return content
     if isinstance(content, list):
         parts = [
-            p.get("text", "")
-            for p in content
-            if isinstance(p, dict) and p.get("type") == "text"
+            p.get("text", "") for p in content if isinstance(p, dict) and p.get("type") == "text"
         ]
         return "\n".join(x for x in parts if x)
     return ""
@@ -329,7 +328,7 @@ def _record(
 
         _write(
             {
-                "ts": datetime.now(timezone.utc).isoformat(),
+                "ts": datetime.now(UTC).isoformat(),
                 "turn_id": _turn_id.get(),
                 "turn_meta": _turn_meta.get(),
                 "seq": _next_seq(),
@@ -361,11 +360,11 @@ def _sync_request_hook(request: httpx.Request) -> None:
 
 
 def _sync_response_hook(response: httpx.Response) -> None:
-    elapsed = _elapsed_ms(response)          # before the body read, always
+    elapsed = _elapsed_ms(response)  # before the body read, always
     usage = None
     if not _is_streaming(response):
         try:
-            response.read()                  # httpx caches it; the SDK re-reads for free
+            response.read()  # httpx caches it; the SDK re-reads for free
             usage = _parse_usage(response)
         except Exception:  # noqa: BLE001
             pass
@@ -377,7 +376,7 @@ async def _async_request_hook(request: httpx.Request) -> None:
 
 
 async def _async_response_hook(response: httpx.Response) -> None:
-    elapsed = _elapsed_ms(response)          # before the body read, always
+    elapsed = _elapsed_ms(response)  # before the body read, always
     usage = None
     if not _is_streaming(response):
         try:

--- a/src/continuum/llm/timing_probe.py
+++ b/src/continuum/llm/timing_probe.py
@@ -81,6 +81,9 @@ _START_KEY = "continuum_probe_start"
 # which is still a usable per-call log.
 _turn_id: ContextVar[str | None] = ContextVar("continuum_timing_turn_id", default=None)
 _turn_seq: ContextVar[int] = ContextVar("continuum_timing_turn_seq", default=0)
+_turn_meta: ContextVar["dict[str, Any] | None"] = ContextVar(
+    "continuum_timing_turn_meta", default=None
+)
 
 # The sync client may be driven from a worker thread, so the append is locked.
 # Held only around the write itself, never around the request.
@@ -101,7 +104,7 @@ def log_path() -> str:
 
 
 @contextmanager
-def timing_turn(turn_id: str) -> Iterator[None]:
+def timing_turn(turn_id: str, meta: dict[str, Any] | None = None) -> Iterator[None]:
     """Tag every LLM call made inside this block with `turn_id`.
 
     A contextvar rather than a parameter because the call sites are several
@@ -109,20 +112,95 @@ def timing_turn(turn_id: str) -> Iterator[None]:
     exists. Also restores the previous value on exit, so nested turns (a memory
     extraction call made while handling a user turn) cannot leak their id
     outward.
+
+    `meta` is copied onto every record from this turn — the user's question, the
+    model asked for, whatever makes the rollup readable. Kept small on purpose:
+    it is repeated on each of the turn's records rather than stored once.
     """
     token_id = _turn_id.set(turn_id)
     token_seq = _turn_seq.set(0)
+    token_meta = _turn_meta.set(dict(meta) if meta else None)
     try:
         yield
     finally:
         _turn_id.reset(token_id)
         _turn_seq.reset(token_seq)
+        _turn_meta.reset(token_meta)
 
 
 def _next_seq() -> int:
     seq = _turn_seq.get() + 1
     _turn_seq.set(seq)
     return seq
+
+
+# Bodies above this are not inspected. A request carrying base64 images can be
+# tens of megabytes, and parsing it to count roles would cost more than the
+# phases being measured — the probe must not distort its own measurement.
+_MAX_BODY_BYTES_TO_INSPECT = 1_000_000
+
+
+def _content_text(content: Any) -> str:
+    """Text of a message, mirroring the gateway's own `contentToText`.
+
+    Kept deliberately close to the gateway's extraction rules: the point of this
+    field is to predict whether the gateway found a prompt to classify, so an
+    extraction that disagreed with the gateway's would answer the wrong question.
+    """
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts = [
+            p.get("text", "")
+            for p in content
+            if isinstance(p, dict) and p.get("type") == "text"
+        ]
+        return "\n".join(x for x in parts if x)
+    return ""
+
+
+def _describe_request(request: httpx.Request) -> dict[str, Any] | None:
+    """Shape of the outgoing request — enough to explain a skipped phase.
+
+    The gateway classifies the LAST role:'user' message and silently skips
+    classification when that yields no text (`prompt !== null` in
+    middlewares/classifier/index.ts). From outside, that skip is invisible: no
+    classifier_ms, no x-aura-classification header, and a request routed with no
+    complexity signal. Recording the roles and whether a usable user message was
+    present makes the skip diagnosable from the log alone.
+    """
+    try:
+        raw = request.content
+        if not raw or len(raw) > _MAX_BODY_BYTES_TO_INSPECT:
+            return None
+        body = json.loads(raw)
+        if not isinstance(body, dict):
+            return None
+        messages = body.get("messages")
+        if not isinstance(messages, list):
+            return None
+
+        last_user = ""
+        for m in reversed(messages):
+            if isinstance(m, dict) and m.get("role") == "user":
+                last_user = _content_text(m.get("content"))
+                break
+
+        metadata = body.get("metadata")
+        return {
+            "model": body.get("model"),
+            "n_messages": len(messages),
+            "roles": [m.get("role") for m in messages if isinstance(m, dict)],
+            "last_user_chars": len(last_user.strip()),
+            # The gateway's own predicate, evaluated here: False predicts a
+            # skipped classification.
+            "has_user_text": bool(last_user.strip()),
+            "declared_complexity": (
+                metadata.get("complexity") if isinstance(metadata, dict) else None
+            ),
+        }
+    except Exception:  # noqa: BLE001
+        return None
 
 
 def _parse_timing(raw: str | None) -> dict[str, Any] | None:
@@ -165,10 +243,12 @@ def _record(response: httpx.Response) -> None:
             {
                 "ts": datetime.now(timezone.utc).isoformat(),
                 "turn_id": _turn_id.get(),
+                "turn_meta": _turn_meta.get(),
                 "seq": _next_seq(),
                 "host": request.url.host,
                 "path": request.url.path,
                 "status": response.status_code,
+                "request": _describe_request(request),
                 "client_ms": client_ms,
                 "timing": _parse_timing(response.headers.get(_TIMING_HEADER)),
                 "request_id": response.headers.get(_REQUEST_ID_HEADER),

--- a/src/continuum/llm/timing_probe.py
+++ b/src/continuum/llm/timing_probe.py
@@ -1,0 +1,238 @@
+"""Client-side latency probe for LLM HTTP calls.
+
+Phase 1a of the gateway latency measurement plan. Exists because the OpenAI SDK
+discards response headers: the gateway stamps every response with
+``x-aura-timing`` carrying its per-phase breakdown, and until now nothing on the
+Continuum side ever read it.
+
+Rather than rewrite every call site to use ``with_raw_response``, the probe
+installs an httpx event hook on the client the SDK already uses. Call sites are
+untouched and return types are unchanged.
+
+Enabled by ``CONTINUUM_TIMING_LOG=1``. When unset, the ``build_*_http_client``
+functions return ``None`` and the provider constructs its clients exactly as it
+did before — no hook, no file, no import cost beyond this module.
+
+One JSON object per HTTP call is appended to ``CONTINUUM_TIMING_LOG_PATH``
+(default ``continuum-timing.jsonl`` in the working directory):
+
+    ts            wall-clock ISO timestamp — a point in time, so Date-based
+    turn_id       set by the caller via `timing_turn`; None outside a turn
+    seq           per-turn call ordinal, so a turn's calls stay ordered even if
+                  two finish in the same millisecond
+    host, path    which endpoint; direct-OpenAI calls are logged too, which is
+                  what makes the Phase 3 A/B control possible
+    status        HTTP status
+    client_ms     round trip as the CALLER sees it — see the note below
+    timing        parsed x-aura-timing, or None when absent
+    request_id    x-request-id, for joining against gateway logs and Langfuse
+
+`client_ms` is measured with ``time.perf_counter()``, not ``time.time()``, for
+the same reason the gateway moved to ``performance.now()``: the wall clock is
+coarse and can step backwards, and a sub-millisecond span must not floor to zero.
+
+WHAT `client_ms` INCLUDES that the gateway's own `gateway_total_ms` cannot:
+connection setup, TLS, network transit both ways, and the five middleware
+wrappers mounted outside `requestTiming`. The difference between the two is the
+only view we have of the edge, so both are recorded rather than one.
+
+STREAMING CAVEAT: httpx fires the response hook when the response *headers*
+arrive, before the body is consumed. On a streaming call `client_ms` is
+therefore time-to-headers, not total time — and `timing` will usually be None,
+because the gateway cannot stamp a header onto a body that is already flowing.
+Measure with streaming off; a streaming-aware probe is a separate exercise.
+
+The probe never raises into the request path. Every hook body is wrapped: a
+broken probe degrades to missing measurements, never to a failed LLM call.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import threading
+import time
+from contextlib import contextmanager
+from contextvars import ContextVar
+from datetime import datetime, timezone
+from typing import Any, Iterator
+
+import httpx
+
+from continuum.logging import get_logger
+
+logger = get_logger(__name__)
+
+_ENV_ENABLED = "CONTINUUM_TIMING_LOG"
+_ENV_PATH = "CONTINUUM_TIMING_LOG_PATH"
+_DEFAULT_PATH = "continuum-timing.jsonl"
+
+_TIMING_HEADER = "x-aura-timing"
+_REQUEST_ID_HEADER = "x-request-id"
+
+# Stamped onto the outgoing request by the request hook and read back by the
+# response hook. httpx carries `extensions` through to `response.request`, and
+# it is the documented place for per-request user data — unlike setattr, which
+# is not part of the Request contract.
+_START_KEY = "continuum_probe_start"
+
+# One turn is one user query, which fans out into several LLM calls. Phase 1b
+# sets this from the agent loop; until then every record carries turn_id=None,
+# which is still a usable per-call log.
+_turn_id: ContextVar[str | None] = ContextVar("continuum_timing_turn_id", default=None)
+_turn_seq: ContextVar[int] = ContextVar("continuum_timing_turn_seq", default=0)
+
+# The sync client may be driven from a worker thread, so the append is locked.
+# Held only around the write itself, never around the request.
+_write_lock = threading.Lock()
+
+
+def is_enabled() -> bool:
+    """Whether the probe should install itself.
+
+    Read on every client construction rather than cached at import, so a test or
+    a REPL can toggle it without reimporting the module.
+    """
+    return os.environ.get(_ENV_ENABLED, "").strip().lower() in {"1", "true", "yes"}
+
+
+def log_path() -> str:
+    return os.environ.get(_ENV_PATH, "").strip() or _DEFAULT_PATH
+
+
+@contextmanager
+def timing_turn(turn_id: str) -> Iterator[None]:
+    """Tag every LLM call made inside this block with `turn_id`.
+
+    A contextvar rather than a parameter because the call sites are several
+    frames below the agent loop and none of them should have to know the probe
+    exists. Also restores the previous value on exit, so nested turns (a memory
+    extraction call made while handling a user turn) cannot leak their id
+    outward.
+    """
+    token_id = _turn_id.set(turn_id)
+    token_seq = _turn_seq.set(0)
+    try:
+        yield
+    finally:
+        _turn_id.reset(token_id)
+        _turn_seq.reset(token_seq)
+
+
+def _next_seq() -> int:
+    seq = _turn_seq.get() + 1
+    _turn_seq.set(seq)
+    return seq
+
+
+def _parse_timing(raw: str | None) -> dict[str, Any] | None:
+    """Parse the gateway's timing header, keeping only numeric phases.
+
+    Deliberately unfiltered against a known-phase list: the gateway's registry is
+    the authority on what phases exist, and a probe that dropped unrecognised
+    keys would silently hide any phase added after this file was written — which
+    is exactly the failure mode the gateway-side registry was introduced to end.
+    """
+    if not raw:
+        return None
+    try:
+        parsed = json.loads(raw)
+    except (json.JSONDecodeError, TypeError):
+        return None
+    if not isinstance(parsed, dict):
+        return None
+    return {k: v for k, v in parsed.items() if isinstance(v, (int, float))}
+
+
+def _write(record: dict[str, Any]) -> None:
+    path = log_path()
+    line = json.dumps(record, sort_keys=True)
+    with _write_lock:
+        with open(path, "a", encoding="utf-8") as fh:
+            fh.write(line + "\n")
+
+
+def _record(response: httpx.Response) -> None:
+    """Build and append one record. Never raises."""
+    try:
+        request = response.request
+        start = request.extensions.get(_START_KEY)
+        client_ms = (
+            round((time.perf_counter() - start) * 1000, 3) if start is not None else None
+        )
+
+        _write(
+            {
+                "ts": datetime.now(timezone.utc).isoformat(),
+                "turn_id": _turn_id.get(),
+                "seq": _next_seq(),
+                "host": request.url.host,
+                "path": request.url.path,
+                "status": response.status_code,
+                "client_ms": client_ms,
+                "timing": _parse_timing(response.headers.get(_TIMING_HEADER)),
+                "request_id": response.headers.get(_REQUEST_ID_HEADER),
+            }
+        )
+    except Exception:  # noqa: BLE001 — a probe must never break the call it measures
+        logger.debug("timing probe: failed to record a response", exc_info=True)
+
+
+def _stamp(request: httpx.Request) -> None:
+    """Mark the send time. Never raises."""
+    try:
+        request.extensions[_START_KEY] = time.perf_counter()
+    except Exception:  # noqa: BLE001
+        logger.debug("timing probe: failed to stamp a request", exc_info=True)
+
+
+def _sync_request_hook(request: httpx.Request) -> None:
+    _stamp(request)
+
+
+def _sync_response_hook(response: httpx.Response) -> None:
+    _record(response)
+
+
+async def _async_request_hook(request: httpx.Request) -> None:
+    _stamp(request)
+
+
+async def _async_response_hook(response: httpx.Response) -> None:
+    _record(response)
+
+
+def build_sync_http_client() -> httpx.Client | None:
+    """An SDK-default httpx client with the probe attached, or None if disabled.
+
+    Built from ``openai.DefaultHttpxClient`` rather than a bare ``httpx.Client``
+    on purpose. The SDK's client applies its own timeout and connection-pool
+    limits; a bare client would silently replace both, changing the very latency
+    this probe exists to measure. ``DefaultHttpxClient`` applies them with
+    ``setdefault`` and passes everything else — including ``event_hooks`` —
+    through untouched.
+    """
+    if not is_enabled():
+        return None
+    from openai import DefaultHttpxClient
+
+    return DefaultHttpxClient(
+        event_hooks={
+            "request": [_sync_request_hook],
+            "response": [_sync_response_hook],
+        }
+    )
+
+
+def build_async_http_client() -> httpx.AsyncClient | None:
+    """Async counterpart of `build_sync_http_client`."""
+    if not is_enabled():
+        return None
+    from openai import DefaultAsyncHttpxClient
+
+    return DefaultAsyncHttpxClient(
+        event_hooks={
+            "request": [_async_request_hook],
+            "response": [_async_response_hook],
+        }
+    )

--- a/src/continuum/llm/timing_probe.py
+++ b/src/continuum/llm/timing_probe.py
@@ -29,6 +29,10 @@ One JSON object per HTTP call is appended to ``CONTINUUM_TIMING_LOG_PATH``
                   per-attempt served candidates, cache status), or None on a
                   direct-to-provider call. `router_attempts` is the only in-band
                   record of which effort alias actually ran.
+    usage         prompt/completion/reasoning token counts, parsed from the body.
+                  `reasoning_tokens` is the only in-band proof that a
+                  `reasoning_effort` sent via extra_body actually applied. None on
+                  streaming responses, whose body must not be consumed here.
     request_id    x-request-id, for joining against gateway logs and Langfuse
 
 `client_ms` is measured with ``time.perf_counter()``, not ``time.time()``, for
@@ -241,6 +245,38 @@ def _parse_timing(raw: str | None) -> dict[str, Any] | None:
     return {k: v for k, v in parsed.items() if isinstance(v, (int, float))}
 
 
+def _is_streaming(response: httpx.Response) -> bool:
+    """Whether reading this body would consume a stream the SDK still needs."""
+    return "text/event-stream" in (response.headers.get("content-type") or "")
+
+
+def _parse_usage(response: httpx.Response) -> dict[str, int] | None:
+    """Token usage, including the reasoning count. Assumes the body is read.
+
+    `reasoning_tokens` is the only in-band proof that a `reasoning_effort` sent
+    via extra_body actually took effect — the request carries the intent, and
+    nothing else in the response reflects it. Without it, an effort setting that
+    silently fails to apply is indistinguishable from one that worked, which is
+    exactly the confound this probe exists to prevent.
+    """
+    try:
+        body = json.loads(response.content)
+        u = body.get("usage") or {}
+        details = u.get("completion_tokens_details") or {}
+        out = {
+            k: v
+            for k, v in (
+                ("prompt_tokens", u.get("prompt_tokens")),
+                ("completion_tokens", u.get("completion_tokens")),
+                ("reasoning_tokens", details.get("reasoning_tokens")),
+            )
+            if isinstance(v, int)
+        }
+        return out or None
+    except Exception:  # noqa: BLE001
+        return None
+
+
 def _parse_routing(headers: Any) -> dict[str, str] | None:
     """The gateway's routing decision, or None when absent.
 
@@ -267,14 +303,29 @@ def _write(record: dict[str, Any]) -> None:
             fh.write(line + "\n")
 
 
-def _record(response: httpx.Response) -> None:
-    """Build and append one record. Never raises."""
+def _elapsed_ms(response: httpx.Response) -> float | None:
+    """Time since the request was stamped. Must be read BEFORE the body is."""
+    try:
+        start = response.request.extensions.get(_START_KEY)
+        return round((time.perf_counter() - start) * 1000, 3) if start is not None else None
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def _record(
+    response: httpx.Response,
+    client_ms: float | None = None,
+    usage: dict[str, int] | None = None,
+) -> None:
+    """Build and append one record. Never raises.
+
+    `client_ms` is passed in rather than computed here: the caller measures it
+    before reading the body, so that reading the body for `usage` cannot inflate
+    the very number this probe exists to report. It stays time-to-HEADERS, as it
+    always was.
+    """
     try:
         request = response.request
-        start = request.extensions.get(_START_KEY)
-        client_ms = (
-            round((time.perf_counter() - start) * 1000, 3) if start is not None else None
-        )
 
         _write(
             {
@@ -289,6 +340,7 @@ def _record(response: httpx.Response) -> None:
                 "client_ms": client_ms,
                 "timing": _parse_timing(response.headers.get(_TIMING_HEADER)),
                 "routing": _parse_routing(response.headers),
+                "usage": usage,
                 "request_id": response.headers.get(_REQUEST_ID_HEADER),
             }
         )
@@ -309,7 +361,15 @@ def _sync_request_hook(request: httpx.Request) -> None:
 
 
 def _sync_response_hook(response: httpx.Response) -> None:
-    _record(response)
+    elapsed = _elapsed_ms(response)          # before the body read, always
+    usage = None
+    if not _is_streaming(response):
+        try:
+            response.read()                  # httpx caches it; the SDK re-reads for free
+            usage = _parse_usage(response)
+        except Exception:  # noqa: BLE001
+            pass
+    _record(response, client_ms=elapsed, usage=usage)
 
 
 async def _async_request_hook(request: httpx.Request) -> None:
@@ -317,7 +377,15 @@ async def _async_request_hook(request: httpx.Request) -> None:
 
 
 async def _async_response_hook(response: httpx.Response) -> None:
-    _record(response)
+    elapsed = _elapsed_ms(response)          # before the body read, always
+    usage = None
+    if not _is_streaming(response):
+        try:
+            await response.aread()
+            usage = _parse_usage(response)
+        except Exception:  # noqa: BLE001
+            pass
+    _record(response, client_ms=elapsed, usage=usage)
 
 
 def build_sync_http_client() -> httpx.Client | None:

--- a/src/continuum/llm/timing_probe.py
+++ b/src/continuum/llm/timing_probe.py
@@ -25,6 +25,10 @@ One JSON object per HTTP call is appended to ``CONTINUUM_TIMING_LOG_PATH``
     status        HTTP status
     client_ms     round trip as the CALLER sees it — see the note below
     timing        parsed x-aura-timing, or None when absent
+    routing       the gateway's own routing decision (mode, complexity, domain,
+                  per-attempt served candidates, cache status), or None on a
+                  direct-to-provider call. `router_attempts` is the only in-band
+                  record of which effort alias actually ran.
     request_id    x-request-id, for joining against gateway logs and Langfuse
 
 `client_ms` is measured with ``time.perf_counter()``, not ``time.time()``, for
@@ -69,6 +73,21 @@ _DEFAULT_PATH = "continuum-timing.jsonl"
 
 _TIMING_HEADER = "x-aura-timing"
 _REQUEST_ID_HEADER = "x-request-id"
+
+# The routing decision the gateway actually made. Recorded because the request
+# body only carries what was ASKED for ("auto/mid") and the response body carries
+# the BASE model id — effort aliases (`-low`/`-medium`/`-high`) are rewritten to
+# that base id plus `reasoning_effort` before dispatch, so a served id of
+# `gpt-5-nano-2025-08-07` is consistent with all three. Without these, which
+# model ran can only be inferred from a separate /v1/classify/auto dry run, which
+# answers "what would the router pick now", not "what did it pick then".
+_ROUTER_HEADERS = {
+    "router_mode": "x-aura-router-mode",
+    "router_complexity": "x-aura-router-complexity",
+    "router_domain": "x-aura-router-domain",
+    "router_attempts": "x-aura-router-attempts",
+    "cache_status": "x-aura-cache-status",
+}
 
 # Stamped onto the outgoing request by the request hook and read back by the
 # response hook. httpx carries `extensions` through to `response.request`, and
@@ -222,6 +241,24 @@ def _parse_timing(raw: str | None) -> dict[str, Any] | None:
     return {k: v for k, v in parsed.items() if isinstance(v, (int, float))}
 
 
+def _parse_routing(headers: Any) -> dict[str, str] | None:
+    """The gateway's routing decision, or None when absent.
+
+    None on any direct-to-provider call — there is no gateway to stamp these —
+    which is itself the signal that a call bypassed the gateway.
+
+    `x-aura-router-attempts` carries the served candidate per attempt
+    (`model@provider:status`), so it is the one field that distinguishes an
+    effort alias from its base id, and the only in-band record of a failover.
+    """
+    out = {
+        name: headers.get(header)
+        for name, header in _ROUTER_HEADERS.items()
+        if headers.get(header) is not None
+    }
+    return out or None
+
+
 def _write(record: dict[str, Any]) -> None:
     path = log_path()
     line = json.dumps(record, sort_keys=True)
@@ -251,6 +288,7 @@ def _record(response: httpx.Response) -> None:
                 "request": _describe_request(request),
                 "client_ms": client_ms,
                 "timing": _parse_timing(response.headers.get(_TIMING_HEADER)),
+                "routing": _parse_routing(response.headers),
                 "request_id": response.headers.get(_REQUEST_ID_HEADER),
             }
         )

--- a/src/continuum/llm/types.py
+++ b/src/continuum/llm/types.py
@@ -6,7 +6,7 @@ Provides Pydantic models for structured data handling with LLM responses.
 
 from typing import Any, Literal
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 # Type alias for tool call input (can be ToolCall object or dict)
 # Used throughout the SDK for flexible tool call handling
@@ -18,15 +18,44 @@ ToolCallDict = dict[str, Any]
 # deserialize nested models when loading from dict/JSON.
 
 
+def provider_extras(function: Any) -> dict[str, Any]:
+    """Provider-specific fields an upstream attached to a tool call's function.
+
+    Tool calls are not always pure data: some providers attach state that must
+    come back unchanged on the next turn. Gemini 3.x signs each function call
+    with a ``thought_signature`` and rejects the whole request (400) if the
+    replayed call lacks it — which only bites from turn 2 onward.
+
+    Reads the extras the SDK already parsed rather than naming fields, so a
+    provider adding one costs no change here. Accepts SDK models (Pydantic,
+    ``extra="allow"``) and plain dicts alike.
+    """
+    if isinstance(function, dict):
+        return {k: v for k, v in function.items() if k not in ("name", "arguments")}
+    extras = getattr(function, "model_extra", None)
+    return dict(extras) if isinstance(extras, dict) else {}
+
+
 class FunctionCall(BaseModel):
-    """Represents a function call in a message."""
+    """Represents a function call in a message.
+
+    Accepts unknown fields so provider-specific state (Gemini's
+    ``thought_signature``, and whatever comes next) survives the round trip
+    instead of being silently dropped between the response and the replay.
+    """
+
+    model_config = ConfigDict(extra="allow")
 
     name: str
     arguments: str  # JSON string of arguments
 
     def to_dict(self) -> dict[str, Any]:
-        """Convert to dictionary format."""
-        return {"name": self.name, "arguments": self.arguments}
+        """Convert to dictionary format, including any provider extras.
+
+        Extras are emitted only when present, so a provider that sends none
+        still receives exactly the OpenAI shape it expects.
+        """
+        return {"name": self.name, "arguments": self.arguments, **(self.model_extra or {})}
 
 
 class ToolCall(BaseModel):
@@ -140,6 +169,7 @@ class LLMResponse(BaseModel):
                     function=FunctionCall(
                         name=tc.function.name,
                         arguments=tc.function.arguments,
+                        **provider_extras(tc.function),
                     ),
                 )
                 for tc in message.tool_calls
@@ -252,6 +282,7 @@ class StreamChunk(BaseModel):
                     function=FunctionCall(
                         name=tc.function.name or "",
                         arguments=tc.function.arguments or "",
+                        **provider_extras(tc.function),
                     ),
                 )
                 for tc in delta.tool_calls

--- a/tests/unit/agent/test_structured_output_stream.py
+++ b/tests/unit/agent/test_structured_output_stream.py
@@ -43,6 +43,7 @@ def _make_agent(*, with_schema=True):
     agent.temperature = 0.7
     agent.max_tokens = 1024
     agent.gateway_mode = None
+    agent.extra_body = None
     agent.enable_json_mode = False
     agent.json_schema = None
     agent.json_strict = False

--- a/tests/unit/agent/test_tool_attention_wiring.py
+++ b/tests/unit/agent/test_tool_attention_wiring.py
@@ -232,6 +232,7 @@ def _make_stream_agent(tool_attention=None, num_tools: int = 5):
     agent.temperature = 0.7
     agent.max_tokens = 1024
     agent.gateway_mode = None
+    agent.extra_body = None
     agent.enable_json_mode = False
     agent.json_schema = None
     agent.json_strict = False

--- a/tests/unit/llm/test_config.py
+++ b/tests/unit/llm/test_config.py
@@ -19,6 +19,7 @@ def _legacy_json_agent(json_schema):
     agent.temperature = 0.7
     agent.max_tokens = 4096
     agent.gateway_mode = None
+    agent.extra_body = None
     agent.enable_json_mode = True
     agent.json_schema = json_schema
     return agent
@@ -116,6 +117,7 @@ class TestLLMConfig:
         agent.temperature = 0.3
         agent.max_tokens = 200
         agent.gateway_mode = None
+        agent.extra_body = None
         agent.enable_json_mode = False
         agent.json_schema = None
         c = LLMConfig.from_agent_config(agent)
@@ -133,6 +135,7 @@ class TestLLMConfig:
         agent.temperature = 0.7
         agent.max_tokens = 4096
         agent.gateway_mode = None
+        agent.extra_body = None
         agent.enable_json_mode = True
         agent.json_schema = None
         c = LLMConfig.from_agent_config(agent)

--- a/tests/unit/llm/test_provider_matrix_structured_output.py
+++ b/tests/unit/llm/test_provider_matrix_structured_output.py
@@ -161,6 +161,7 @@ def _stream_agent():
     agent.temperature = 0.7
     agent.max_tokens = 1024
     agent.gateway_mode = None
+    agent.extra_body = None
     agent.enable_json_mode = False
     agent.json_schema = None
     agent.json_strict = False

--- a/tests/unit/llm/test_tool_call_provider_extras.py
+++ b/tests/unit/llm/test_tool_call_provider_extras.py
@@ -1,0 +1,199 @@
+"""
+Tool calls must round-trip provider-specific fields.
+
+Gemini 3.x attaches a `thought_signature` to every function call and REQUIRES it
+back on the next turn; without it the whole request is rejected with a 400. The
+Smart Gateway already carries the field in both directions (it surfaces Google's
+`thoughtSignature` as `tool_calls[].function.thought_signature`, and replays an
+incoming one back to Google) — but Continuum parsed tool calls field-by-field
+into a closed two-field model, so the signature was dropped on arrival and
+absent from the assistant message replayed on turn 2.
+
+Turn 1 therefore succeeded and turn 2 always failed, which is why single-shot
+schema tests never caught it.
+
+The fix is deliberately generic rather than a `thought_signature` field: any
+provider may attach state to a tool call, and a closed shape loses all of it.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from continuum.llm.types import ChatMessage, FunctionCall, LLMResponse, StreamChunk, ToolCall
+
+SIGNATURE = "opaque-google-signature"
+
+
+def _openai_completion(**function_fields):
+    """An OpenAI-shaped completion carrying one tool call, as the gateway emits it."""
+    from openai.types.chat import ChatCompletion
+
+    return ChatCompletion.model_validate(
+        {
+            "id": "chatcmpl-1",
+            "object": "chat.completion",
+            "created": 0,
+            "model": "google/gemini-3.5-flash",
+            "choices": [
+                {
+                    "index": 0,
+                    "finish_reason": "tool_calls",
+                    "message": {
+                        "role": "assistant",
+                        "content": None,
+                        "tool_calls": [
+                            {
+                                "id": "call_1",
+                                "type": "function",
+                                "function": {
+                                    "name": "sql_execute",
+                                    "arguments": '{"q": "select 1"}',
+                                    **function_fields,
+                                },
+                            }
+                        ],
+                    },
+                }
+            ],
+        }
+    )
+
+
+class TestNonStreamingRoundTrip:
+    def test_signature_survives_parsing(self):
+        response = LLMResponse.from_openai_response(_openai_completion(thought_signature=SIGNATURE))
+
+        assert response.tool_calls[0].function.thought_signature == SIGNATURE
+
+    def test_signature_is_replayed_on_the_next_turn(self):
+        # to_dict() is what executor.py rebuilds the assistant message from, so
+        # this is the exact payload that goes back to the gateway on turn 2.
+        response = LLMResponse.from_openai_response(_openai_completion(thought_signature=SIGNATURE))
+
+        replayed = response.tool_calls[0].to_dict()
+
+        assert replayed["function"]["thought_signature"] == SIGNATURE
+        assert replayed["function"]["name"] == "sql_execute"
+        assert replayed["id"] == "call_1"
+
+    def test_assistant_message_carries_it_through_chatmessage(self):
+        response = LLMResponse.from_openai_response(_openai_completion(thought_signature=SIGNATURE))
+
+        message = ChatMessage(role="assistant", tool_calls=response.tool_calls).to_dict()
+
+        assert message["tool_calls"][0]["function"]["thought_signature"] == SIGNATURE
+
+    def test_absent_extras_add_no_keys(self):
+        # A provider that sends nothing extra must produce exactly the OpenAI
+        # shape — no `thought_signature: None` echoed back at OpenAI itself.
+        response = LLMResponse.from_openai_response(_openai_completion())
+
+        assert response.tool_calls[0].to_dict()["function"] == {
+            "name": "sql_execute",
+            "arguments": '{"q": "select 1"}',
+        }
+
+    def test_multiple_extras_are_all_preserved(self):
+        response = LLMResponse.from_openai_response(
+            _openai_completion(thought_signature=SIGNATURE, some_future_field="x")
+        )
+
+        function = response.tool_calls[0].to_dict()["function"]
+        assert function["thought_signature"] == SIGNATURE
+        assert function["some_future_field"] == "x"
+
+
+class TestStreamingRoundTrip:
+    def test_stream_chunk_preserves_the_signature(self):
+        chunk = SimpleNamespace(
+            id="chatcmpl-1",
+            model="google/gemini-3.5-flash",
+            choices=[
+                SimpleNamespace(
+                    finish_reason=None,
+                    delta=SimpleNamespace(
+                        content=None,
+                        role="assistant",
+                        tool_calls=[
+                            SimpleNamespace(
+                                id="call_1",
+                                type="function",
+                                function=_function_delta(
+                                    "sql_execute", "{}", thought_signature=SIGNATURE
+                                ),
+                            )
+                        ],
+                    ),
+                )
+            ],
+        )
+
+        parsed = StreamChunk.from_openai_chunk(chunk)
+
+        assert parsed.tool_calls[0].function.thought_signature == SIGNATURE
+
+    def test_openai_provider_accumulator_preserves_the_signature(self):
+        from continuum.llm.providers.openai_provider import OpenAIProvider
+
+        acc: dict = {}
+        OpenAIProvider._accumulate_tool_call(
+            acc,
+            SimpleNamespace(
+                index=0,
+                id="call_1",
+                function=_function_delta("sql_", "{}", thought_signature=SIGNATURE),
+            ),
+        )
+        # Signature arrives on the first delta; later deltas carry only argument text.
+        OpenAIProvider._accumulate_tool_call(
+            acc,
+            SimpleNamespace(index=0, id=None, function=_function_delta("execute", '{"q":1}')),
+        )
+
+        built = OpenAIProvider._build_tool_calls_from_acc(acc)
+
+        assert built[0].function.name == "sql_execute"
+        assert built[0].function.thought_signature == SIGNATURE
+
+    def test_gemini_provider_accumulator_preserves_the_signature(self):
+        from continuum.llm.providers.gemini_provider import GeminiProvider
+
+        acc: dict = {}
+        GeminiProvider._accumulate_tool_call(
+            acc,
+            SimpleNamespace(
+                index=0,
+                id="call_1",
+                function=_function_delta("sql_execute", "{}", thought_signature=SIGNATURE),
+            ),
+        )
+
+        built = GeminiProvider._build_tool_calls_from_acc(acc)
+
+        assert built[0].function.thought_signature == SIGNATURE
+
+
+class TestConstructionIsUnaffected:
+    def test_plain_construction_still_works(self):
+        call = ToolCall(id="1", function=FunctionCall(name="f", arguments="{}"))
+
+        assert call.to_dict() == {
+            "id": "1",
+            "type": "function",
+            "function": {"name": "f", "arguments": "{}"},
+        }
+
+    def test_extras_can_be_set_explicitly(self):
+        call = FunctionCall(name="f", arguments="{}", thought_signature=SIGNATURE)
+
+        assert call.to_dict()["thought_signature"] == SIGNATURE
+
+
+def _function_delta(name, arguments, **extras):
+    """A streaming function delta as the openai SDK models it (extras allowed)."""
+    from openai.types.chat.chat_completion_chunk import ChoiceDeltaToolCallFunction
+
+    return ChoiceDeltaToolCallFunction.model_validate(
+        {"name": name, "arguments": arguments, **extras}
+    )

--- a/tests/unit/test_streaming_handoffs.py
+++ b/tests/unit/test_streaming_handoffs.py
@@ -72,11 +72,14 @@ def _make_agent(name: str = "source-agent", handoff_target: str = "target-agent"
 
     # Real values for everything LLMConfig.from_agent_config() feeds into pydantic
     # on the streaming-handoff path. The mock predates the Smart-Gateway
-    # `gateway_mode` field, so these must be concrete (not auto-MagicMock).
+    # `gateway_mode` and `extra_body` fields, so these must be concrete: a bare
+    # MagicMock auto-creates the attribute, so from_agent_config's getattr
+    # default never fires and pydantic rejects the mock as not a str/dict.
     agent.model = "gpt-4o-mini"
     agent.temperature = 0.7
     agent.max_tokens = 1024
     agent.gateway_mode = None
+    agent.extra_body = None
     agent.enable_json_mode = False
     agent.json_schema = None
     agent.json_strict = False


### PR DESCRIPTION
Five commits. Four came out of measuring gateway-vs-direct latency; the fifth is an unrelated bug fix reported by an SDK consumer. They can be split if a reviewer would rather take them separately.

## Latency measurement work

**`caf2cd5` — client-side latency probe.** New `src/continuum/llm/timing_probe.py`, opt-in via `CONTINUUM_TIMING_LOG=1`.

**`51070c8` — playground timing rolled up per user question.**

**`158d738` — `extra_body` threading, and recording the routing decision.** Two gaps that each made a measurement answer a different question than it appeared to:

- The gpt-5 family's `reasoning_effort` had no route from an agent to the provider call. `LLMConfig.extra_body` existed and `openai_provider` already applied it, but nothing built one — so a direct run of `openai/gpt-5-nano` used default effort while the gateway arm it was compared against dispatched `effort=high`. On one prompt that's **1280 vs 6016 reasoning tokens, 13.7s vs 43.6s** — a 3.2x gap that would have been misread as the gateway's cost. Threaded at `LLMConfig.from_agent_config`, the single bridge both executors pass through, rather than at each call site.
- The probe recorded only `x-aura-timing`, so which model actually served a turn wasn't recoverable — the request carries what was *asked* (`auto/mid`) and the response carries the *base* id, because effort aliases are rewritten to base + `reasoning_effort` before dispatch.

**`8257ce9` — token usage in the probe, without disturbing `client_ms`.** `reasoning_tokens` is the only in-band proof that a `reasoning_effort` sent via `extra_body` actually applied; without it, a silently-failing effort setting is indistinguishable from a working one. The care is in *where* the body is read: httpx fires response hooks **before** the body is read, so the naive version would have silently redefined `client_ms` from time-to-headers to time-to-full-body across every measurement already taken. `_elapsed_ms()` is computed first in the hook; the body read happens after, and only for non-streaming responses (reading an SSE body there would consume the stream the SDK still needs).

Probe output is gitignored — every record carries `turn_meta.question`, the user's actual prompt, so it must never be committed. The rule is a glob rather than an exact name, because parked/renamed variants carry the same payload and escaped the previous rule.

## Unrelated bug fix

**`3e3c885` — round-trip provider state attached to tool calls.**

Reported against `provider=gateway` on `google/gemini-3.5-flash`: turn 1 succeeds, turn 2 always fails with a 400 at position 2. Gemini 3.x signs every function call with a `thought_signature` and requires it back on the next turn. Single-shot `json_schema` tests passed, which is why this only surfaced under a multi-turn tool exchange.

The Smart Gateway already carries the field both ways — it surfaces Google's `part.thoughtSignature` as `tool_calls[].function.thought_signature`, and replays an incoming one back to Google behind a truthiness guard. Nothing was missing there. **Continuum was the drop point, twice:**

- **parse** — `from_openai_response` / `from_openai_chunk` built `FunctionCall` by copying exactly `name` and `arguments`, and the model declared only those two fields. The signature arrives intact on the openai SDK object (its models allow extras) and was discarded on the way in.
- **replay** — `FunctionCall.to_dict()` hard-coded the same two keys, so the assistant message `executor.py` rebuilds for turn 2 couldn't carry it even if parsing had kept it.

The streaming accumulators in `openai_provider` and `gemini_provider` dropped it a third time.

Fixed generically rather than by adding a `thought_signature` field: a tool call isn't always pure data, and a closed shape loses whatever a provider attaches. `FunctionCall` now allows extras and emits them from `to_dict()`; a new `provider_extras()` helper reads what the SDK already parsed. Extras are emitted only when present, so a provider that sends none still gets the exact OpenAI shape. Anthropic's parse sites are deliberately untouched — `tool_use` blocks carry no OpenAI-shaped function extras, so copying there would be speculative.

**Verified live** against a running gateway and real Gemini 3.x (`google/gemini-3-flash-preview`), as a controlled A/B — a passing run alone would not show the fix caused it. Same two-turn script both arms, building the turn-2 replay with the exact code from `executor.py:433-441`; the control arm patches `to_dict()` back to its pre-fix two-key form:

| | turn 1 signature | replayed on turn 2 | turn 2 result |
|---|---|---|---|
| pre-fix (control) | PRESENT | ✗ | **400** |
| post-fix (shipped) | PRESENT | ✓ | **200**, `finish_reason=stop` |

The control arm reproduces the reported error verbatim, down to the position:

```
400 - google error: Function call is missing a thought_signature in functionCall
parts. This is required for tools to work correctly... Additional data,
function call `default_api:describe_table`, position 2.
```

`turn 1: thought_signature=PRESENT` also confirms the gateway does emit the field on the wire for this model, which had been an assumption.

## Checks

- **1938 unit tests pass**, 1 skipped, 0 failures
- 10 new tests for the tool-call round trip, TDD (8 red first, across all four drop points)
- live two-turn Gemini exchange through the gateway, run pre-fix and post-fix (see above)
- `ruff check` / `ruff format --check` clean on changed files; `mypy` unchanged at its pre-existing error count

One note for bisecting: `158d738` also carries a 7-line test fix folded in via `--fixup`. It threads a new `getattr`-sourced field into `from_agent_config`, which broke every `MagicMock`-based agent double — a bare mock auto-creates the attribute, so the `getattr` default never fires and pydantic rejects it. The same trap was hit when `gateway_mode` was added. Without the fold-in, that commit alone left 25 tests failing; it is now green standalone.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)
