### PR TITLE
Fix session ownership validation

### DIFF
--- a/src/continuum/agent/runner.py
+++ b/src/continuum/agent/runner.py
@@ -399,6 +399,7 @@ class AgentRunner:
             from continuum.session.exceptions import (
                 SessionError,
                 SessionNotCreatedError,
+                SessionOwnershipError,
             )
 
             try:
@@ -443,21 +444,30 @@ class AgentRunner:
                         raise SessionNotCreatedError(msg, session_id=context.session_id)
                     logger.warning(msg)
                 else:
-                    # Session exists: check the write/search user_id alignment.
-                    # Memory WRITES scope by the session's user_id; memory SEARCHES
-                    # scope by the run's context.user_id. If they differ, stored
-                    # facts won't be retrievable — a silent, confusing mismatch.
-                    if (
-                        session_metadata.user_id
-                        and context.user_id
-                        and session_metadata.user_id != context.user_id
-                    ):
-                        logger.warning(
-                            f"user_id mismatch: session {context.session_id!r} was created with "
-                            f"user_id={session_metadata.user_id!r} but run() received "
-                            f"user_id={context.user_id!r}. Long-term memory is WRITTEN under the "
-                            f"session's user_id but SEARCHED under run()'s — stored facts won't be "
-                            f"found. Pass the same user_id to run() as the session was created with."
+                    # A session id identifies storage, not the caller. Require an
+                    # exact match for every scope identifier the stored session
+                    # carries before reading history, restoring MCP state, or
+                    # writing a new turn. Warning and continuing here turns a
+                    # leaked session id into cross-user history access.
+                    ownership_fields = (
+                        ("user_id", session_metadata.user_id, context.user_id),
+                        (
+                            "conversation_id",
+                            session_metadata.conversation_id,
+                            context.conversation_id,
+                        ),
+                    )
+                    mismatches = [
+                        field
+                        for field, stored, supplied in ownership_fields
+                        if stored is not None and stored != supplied
+                    ]
+                    if mismatches:
+                        fields = ", ".join(mismatches)
+                        raise SessionOwnershipError(
+                            f"session_id={context.session_id!r} does not belong to the supplied "
+                            f"{fields}. Refusing to load or modify another session.",
+                            session_id=context.session_id,
                         )
 
             tool_context_state = await self._session_service.load_tool_context_state(
@@ -668,6 +678,8 @@ class AgentRunner:
                 resp = await runner.run(agent, msg, session_id=sid, user_id="user-123")
 
             Omit ``session_id`` for a stateless run (no history, no persistence).
+            When a session is supplied, its stored user and conversation identifiers
+            must exactly match the caller's identifiers.
 
         Args:
             require_session: Override for the session guardrail. When True, raise

--- a/src/continuum/session/__init__.py
+++ b/src/continuum/session/__init__.py
@@ -32,6 +32,7 @@ from continuum.session.exceptions import (
     SessionNotCreatedError,
     SessionNotEnabledError,
     SessionNotFoundError,
+    SessionOwnershipError,
 )
 from continuum.session.providers import (
     create_provider,
@@ -72,5 +73,6 @@ __all__ = [
     "SessionConnectionError",
     "SessionNotFoundError",
     "SessionNotCreatedError",
+    "SessionOwnershipError",
     "SessionMessageLimitError",
 ]

--- a/src/continuum/session/exceptions.py
+++ b/src/continuum/session/exceptions.py
@@ -63,6 +63,18 @@ class SessionNotCreatedError(SessionError):
     pass
 
 
+class SessionOwnershipError(SessionError):
+    """Raised when a caller tries to use a session owned by another scope.
+
+    A session ID is not authorization on its own. When a stored session is
+    bound to a user or conversation, ``AgentRunner`` requires the caller's
+    validated identifiers to match before it loads history, restores tool
+    context, or writes anything back.
+    """
+
+    pass
+
+
 class SessionMessageLimitError(SessionError):
     """Raised when session message limit is exceeded."""
 

--- a/tests/integration/test_session_preflight_redis.py
+++ b/tests/integration/test_session_preflight_redis.py
@@ -10,7 +10,7 @@ Contract verified:
   - session_id passed but never created → WARN by default (run proceeds,
     nothing persisted); RAISE SessionNotCreatedError under strict mode.
   - create-then-run (same id + user_id) → no warning, messages persisted.
-  - user_id mismatch on an existing session → WARN.
+  - a user_id mismatch on an existing session → SessionOwnershipError.
   - stateless run (no session_id) → no guardrail warning at all.
 
 Requires Redis on port 6380 (skipped otherwise).
@@ -29,7 +29,11 @@ from continuum.agent.runner import AgentRunner
 from continuum.llm.types import LLMResponse
 from continuum.session.client import SessionClient
 from continuum.session.config import SessionConfig
-from continuum.session.exceptions import SessionNotCreatedError, SessionNotFoundError
+from continuum.session.exceptions import (
+    SessionNotCreatedError,
+    SessionNotFoundError,
+    SessionOwnershipError,
+)
 from continuum.session.providers.redis import RedisSessionProvider
 
 pytestmark = [pytest.mark.integration, pytest.mark.redis]
@@ -168,21 +172,19 @@ class TestSessionPreflightRedis:
 
         assert resp.status.value == "success"
         assert not cap.has("get_or_create_session")
-        assert not cap.has("user_id mismatch")
+        assert not cap.has("does not belong")
 
         history = await sc.get_conversation_history(sid)
         roles = [m.role for m in history]
         assert "user" in roles and "assistant" in roles
 
-    async def test_user_id_mismatch_warns(self, redis_provider, test_id):
+    async def test_user_id_mismatch_is_rejected(self, redis_provider, test_id):
         sc = _session_client(redis_provider)
         runner = _make_runner(sc)
         sid = await sc.get_or_create_session(session_id=f"mismatch-{test_id}", user_id="u1")
 
-        with _WarnCapture() as cap:
+        with pytest.raises(SessionOwnershipError):
             await runner.run(_make_agent(), "hi", session_id=sid, user_id="u2")
-
-        assert cap.has("user_id mismatch")
 
     async def test_stateless_run_no_guardrail_warning(self, redis_provider):
         # No session_id → stateless. Even with strict mode on, no guardrail fires.
@@ -194,4 +196,4 @@ class TestSessionPreflightRedis:
 
         assert resp.status.value == "success"
         assert not cap.has("get_or_create_session")
-        assert not cap.has("user_id mismatch")
+        assert not cap.has("does not belong")

--- a/tests/unit/test_runner_session_preflight.py
+++ b/tests/unit/test_runner_session_preflight.py
@@ -11,8 +11,9 @@ Contract:
     it) → WARN by default; RAISE SessionNotCreatedError when strict mode is on
     (require_session=True, or SessionConfig.strict_sessions=True). Per-call
     require_session overrides the config.
-  - session exists but its user_id differs from the run's user_id → WARN
-    (memory write/search scope mismatch).
+  - a session bound to a user or conversation only accepts an exact caller
+    identifier match; mismatches raise SessionOwnershipError before history,
+    tool state, or persistence are touched.
   - Persistence degraded (Redis down in 'degrade' mode) → the "missing" signal
     is inconclusive, so never warn/raise about a missing session.
 
@@ -33,7 +34,7 @@ import pytest
 from continuum.agent.base import BaseAgent
 from continuum.agent.config import RunnerConfig
 from continuum.agent.runner import AgentRunner
-from continuum.session.exceptions import SessionNotCreatedError
+from continuum.session.exceptions import SessionNotCreatedError, SessionOwnershipError
 from continuum.session.types import SessionMetadata
 
 
@@ -52,9 +53,18 @@ def _make_agent(name: str = "test-agent") -> BaseAgent:
     return BaseAgent(name=name, instructions="You are a test agent.", model="gpt-4o-mini")
 
 
-def _make_metadata(user_id: str | None) -> SessionMetadata:
+def _make_metadata(
+    user_id: str | None,
+    conversation_id: str | None = None,
+) -> SessionMetadata:
     now = datetime.now(UTC)
-    return SessionMetadata(session_id="abc", user_id=user_id, created_at=now, last_accessed_at=now)
+    return SessionMetadata(
+        session_id="abc",
+        user_id=user_id,
+        conversation_id=conversation_id,
+        created_at=now,
+        last_accessed_at=now,
+    )
 
 
 def _make_session_client(
@@ -160,30 +170,57 @@ class TestSessionNotCreated:
 
 
 # ---------------------------------------------------------------------------
-# 3. Existing session — user_id write/search alignment
+# 3. Existing session — ownership binding
 # ---------------------------------------------------------------------------
 
 
-class TestUserIdMismatch:
+class TestSessionOwnership:
     @pytest.mark.asyncio
-    async def test_mismatch_warns(self):
+    async def test_user_mismatch_raises_before_loading_session_state(self):
         sc = _make_session_client(metadata=_make_metadata("alice"))
-        with _patched_logger() as log:
-            result = await _make_runner(sc)._prepare_run(
-                _make_agent(), "hello", session_id="abc", user_id="bob"
-            )
-        assert result.success is True
-        assert "user_id mismatch" in _warning_text(log)
+        runner = _make_runner(sc)
+        runner._message_builder.prepare_messages = AsyncMock()
+        with pytest.raises(SessionOwnershipError):
+            await runner._prepare_run(_make_agent(), "hello", session_id="abc", user_id="bob")
+        runner._message_builder.prepare_messages.assert_not_awaited()
 
     @pytest.mark.asyncio
-    async def test_matching_user_id_no_warn(self):
+    async def test_owned_session_requires_a_user_id(self):
         sc = _make_session_client(metadata=_make_metadata("alice"))
-        with _patched_logger() as log:
-            result = await _make_runner(sc)._prepare_run(
+        with pytest.raises(SessionOwnershipError):
+            await _make_runner(sc)._prepare_run(_make_agent(), "hello", session_id="abc")
+
+    @pytest.mark.asyncio
+    async def test_conversation_mismatch_raises(self):
+        sc = _make_session_client(metadata=_make_metadata("alice", "conversation-a"))
+        with pytest.raises(SessionOwnershipError):
+            await _make_runner(sc)._prepare_run(
+                _make_agent(),
+                "hello",
+                session_id="abc",
+                user_id="alice",
+                conversation_id="conversation-b",
+            )
+
+    @pytest.mark.asyncio
+    async def test_owned_conversation_requires_a_conversation_id(self):
+        sc = _make_session_client(metadata=_make_metadata("alice", "conversation-a"))
+        with pytest.raises(SessionOwnershipError):
+            await _make_runner(sc)._prepare_run(
                 _make_agent(), "hello", session_id="abc", user_id="alice"
             )
+
+    @pytest.mark.asyncio
+    async def test_matching_identifiers_are_allowed(self):
+        sc = _make_session_client(metadata=_make_metadata("alice", "conversation-a"))
+        result = await _make_runner(sc)._prepare_run(
+            _make_agent(),
+            "hello",
+            session_id="abc",
+            user_id="alice",
+            conversation_id="conversation-a",
+        )
         assert result.success is True
-        assert "user_id mismatch" not in _warning_text(log)
 
     @pytest.mark.asyncio
     async def test_existing_session_no_created_warning(self):


### PR DESCRIPTION
### Problem

A caller could reuse an existing session ID with a different user ID or conversation ID

The runner only logged a warning and continued so session history MCP tool state and later writes could cross the original ownership boundary

Omitting an identifier also allowed access to a session already bound to that identifier

### Fix

The runner now checks stored session ownership before loading any session scoped state

Every stored user ID and conversation ID must match the validated run context and mismatched or omitted identifiers raise SessionOwnershipError

Anonymous sessions with no stored owner remain supported

### Tests

Unit and Redis integration tests cover mismatched users mismatched conversations omitted ownership identifiers valid owners and unbound sessions

51 focused tests pass