### PR TITLE
Fix memory read policy enforcement

### DIFF
--- a/src/continuum/memory/client.py
+++ b/src/continuum/memory/client.py
@@ -312,6 +312,7 @@ class MemoryClient:
         filters: dict[str, Any] | None = None,
         policy_store: "PolicyStore | None" = None,
         subject: str | None = None,
+        data_labels: set[str] | None = None,
     ) -> MemorySearchResult:
         """
         Search memories using semantic similarity.
@@ -323,9 +324,10 @@ class MemoryClient:
             conversation_id: Conversation identifier for scoping
             limit: Maximum results to return
             filters: Additional metadata filters (provider-specific)
-            policy_store: Optional access control policy store. When provided,
-                a "memory:read" resource check is performed before reading.
+            policy_store: Optional access control policy override. The active
+                run policy is used when this is omitted.
             subject: Caller identity for policy evaluation (typically agent name).
+            data_labels: Active data labels included in policy evaluation.
 
         Returns:
             MemorySearchResult with matching memories.
@@ -347,12 +349,17 @@ class MemoryClient:
             )
             query = query[:max_query_chars]
 
-        # Access control check
-        if policy_store is not None and subject is not None:
+        from continuum.security.policy_context import resolve_active_policy
+
+        eff_store, eff_subject, eff_labels = resolve_active_policy(
+            policy_store, subject, data_labels
+        )
+        if eff_store is not None and eff_subject is not None:
             from continuum.agent.exceptions import MemoryAccessDeniedError
 
             scope_label = agent_id or user_id or "unknown"
-            decision = policy_store.check(subject, f"memory:{scope_label}")
+            subjects = [eff_subject, *sorted(eff_labels)] if eff_labels else eff_subject
+            decision = eff_store.check(subjects, f"memory:{scope_label}")
             if not decision.allowed:
                 raise MemoryAccessDeniedError(
                     operation="read",
@@ -566,6 +573,9 @@ class MemoryClient:
         conversation_id: str | None = None,
         limit: int | None = None,
         filters: dict[str, Any] | None = None,
+        policy_store: "PolicyStore | None" = None,
+        subject: str | None = None,
+        data_labels: set[str] | None = None,
     ) -> MemorySearchResult:
         """Synchronous version of search()."""
         return self._run_sync(
@@ -576,6 +586,9 @@ class MemoryClient:
                 conversation_id=conversation_id,
                 limit=limit,
                 filters=filters,
+                policy_store=policy_store,
+                subject=subject,
+                data_labels=data_labels,
             )
         )
 

--- a/src/continuum/memory/intelligence.py
+++ b/src/continuum/memory/intelligence.py
@@ -203,6 +203,7 @@ class IntelligentMemoryClient(MemoryClient):
         filters: dict[str, Any] | None = None,
         policy_store: PolicyStore | None = None,
         subject: str | None = None,
+        data_labels: set[str] | None = None,
     ) -> MemorySearchResult:
         """
         Search memories and re-rank by blending semantic similarity, importance,
@@ -221,6 +222,7 @@ class IntelligentMemoryClient(MemoryClient):
             filters=filters,
             policy_store=policy_store,
             subject=subject,
+            data_labels=data_labels,
         )
 
         if self._intel.enable_scoring or self._intel.enable_decay:

--- a/src/continuum/security/policy_context.py
+++ b/src/continuum/security/policy_context.py
@@ -71,7 +71,7 @@ def resolve_active_policy(
 
     Explicit arguments win; when no ``policy_store`` is passed, fall back to the
     ambient policy published for the current run (and its live labels). Used by
-    every label gate (LLM routing, memory write) so a single ambient publish
+    every label gate (LLM routing, memory access) so a single ambient publish
     covers call sites that don't thread policy params themselves.
     """
     if policy_store is None:

--- a/tests/unit/memory/test_intelligence_contract.py
+++ b/tests/unit/memory/test_intelligence_contract.py
@@ -119,8 +119,15 @@ class TestPolicyArgumentsAreForwarded:
 
         client._intel = IntelligenceConfig(enable_scoring=False, enable_decay=False)
 
-        sentinel_store = object()
-        await client.search("q", user_id="u1", policy_store=sentinel_store, subject="agent-x")
+        sentinel_store, labels = object(), {"pii"}
+        await client.search(
+            "q",
+            user_id="u1",
+            policy_store=sentinel_store,
+            subject="agent-x",
+            data_labels=labels,
+        )
 
         assert captured["policy_store"] is sentinel_store
         assert captured["subject"] == "agent-x"
+        assert captured["data_labels"] == labels

--- a/tests/unit/memory/test_memory_read_policy.py
+++ b/tests/unit/memory/test_memory_read_policy.py
@@ -1,0 +1,86 @@
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from continuum.agent.base import BaseAgent
+from continuum.agent.config import AgentMemoryConfig
+from continuum.agent.exceptions import MemoryAccessDeniedError
+from continuum.agent.services.memory_service import MemoryService
+from continuum.agent.utils.context_utils import create_run_context
+from continuum.memory.client import MemoryClient
+from continuum.memory.config import MemoryConfig
+from continuum.memory.types import MemorySearchResult
+from continuum.security.policy import AccessPolicy, PolicyStore
+from continuum.security.policy_context import use_active_policy
+
+
+def _memory_client() -> MemoryClient:
+    provider = MagicMock()
+    provider.is_initialized = True
+    provider.search = AsyncMock(return_value=MemorySearchResult(results=[], query="query", limit=5))
+    return MemoryClient(
+        config=MemoryConfig(enabled=True, memory_isolation="user"),
+        provider=provider,
+    )
+
+
+def _deny_pii_reads() -> PolicyStore:
+    store = PolicyStore()
+    store.add_policy(
+        AccessPolicy(
+            name="deny_pii_memory_reads",
+            subjects=["pii"],
+            resources=["memory:*"],
+            effect="deny",
+        )
+    )
+    return store
+
+
+class TestMemoryReadPolicy:
+    async def test_explicit_labels_are_checked_before_search(self):
+        client = _memory_client()
+
+        with pytest.raises(MemoryAccessDeniedError):
+            await client.search(
+                "query",
+                user_id="user-1",
+                policy_store=_deny_pii_reads(),
+                subject="assistant",
+                data_labels={"pii"},
+            )
+
+        client.provider.search.assert_not_awaited()
+
+    async def test_automatic_retrieval_uses_ambient_policy(self):
+        client = _memory_client()
+        service = MemoryService(memory_client=client)
+        agent = BaseAgent(
+            name="assistant",
+            instructions="test",
+            memory_config=AgentMemoryConfig(search_memories=True),
+            policy_store=_deny_pii_reads(),
+        )
+        context = create_run_context(user_id="user-1", data_labels={"pii"})
+
+        with use_active_policy(agent.policy_store, agent.name, context):
+            memories = await service.retrieve_memories(agent, "query", context)
+
+        assert memories == []
+        client.provider.search.assert_not_awaited()
+
+    async def test_automatic_retrieval_proceeds_when_allowed(self):
+        client = _memory_client()
+        service = MemoryService(memory_client=client)
+        agent = BaseAgent(
+            name="assistant",
+            instructions="test",
+            memory_config=AgentMemoryConfig(search_memories=True),
+            policy_store=PolicyStore(),
+        )
+        context = create_run_context(user_id="user-1", data_labels={"pii"})
+
+        with use_active_policy(agent.policy_store, agent.name, context):
+            await service.retrieve_memories(agent, "query", context)
+
+        client.provider.search.assert_awaited_once()


### PR DESCRIPTION
### Problem

Automatic memory retrieval calls MemoryClient search without passing a policy store or subject

Search only enforced access policy when those values were passed explicitly so an agent run denied access to memory could still query the provider and retrieve long term memory

Writes already avoided this gap by resolving the active run policy from ambient context

### Fix

Memory reads now use the same ambient policy resolution as writes before the provider is called

The active agent identity and live data labels are evaluated against the target memory scope so deny rules such as memory star block automatic retrieval

Explicit policy arguments still take precedence and the intelligent and synchronous memory clients preserve the same contract

### Tests

Tests verify explicit labeled reads are denied automatic retrieval honors the ambient policy denied reads never reach the provider and allowed reads continue normally

46 focused memory and policy tests pass